### PR TITLE
Degen fix

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -730,7 +730,7 @@ void _phrasematchDegens(uv_work_t* req) {
 
             it = querydist.find(term);
             if (it == querydist.end()) {
-                querydist.emplace(term, term % 16);
+                querydist.emplace(term, degens[i] % 16);
             }
         }
     }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -731,6 +731,8 @@ void _phrasematchDegens(uv_work_t* req) {
             it = querydist.find(term);
             if (it == querydist.end()) {
                 querydist.emplace(term, degens[i] % 16);
+            } else {
+                it->second = degens[i] % 16;
             }
         }
     }

--- a/test/phrasematchDegens.test.js
+++ b/test/phrasematchDegens.test.js
@@ -36,4 +36,23 @@ tape('#phrasematchDegens + dist', function(assert) {
     });
 });
 
+// Edgecase where there are two degen candidates for the same term.
+// The last one currently wins the querydist conflict.
+tape('#phrasematchDegens + dist overwrite', function(assert) {
+    var cache = new Cache('a', 1);
+    cache.phrasematchDegens([
+        [ 681154065 ],
+        [ 681154064 ]
+    ], function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result, {
+            terms: [ 681154064, 681154064 ],
+            queryidx: { '681154064': 0 },
+            querymask: { '681154064': 3 },
+            querydist: { '681154064': 0 }
+        });
+        assert.end();
+    });
+});
+
 

--- a/test/phrasematchDegens.test.js
+++ b/test/phrasematchDegens.test.js
@@ -19,4 +19,21 @@ tape('#phrasematchDegens', function(assert) {
     });
 });
 
+tape('#phrasematchDegens + dist', function(assert) {
+    var cache = new Cache('a', 1);
+    cache.phrasematchDegens([
+        [ 681154065 ],
+        [ 3790501696 ]
+    ], function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result, {
+            terms: [ 681154064, 3790501696 ],
+            queryidx: { '681154064': 0, '3790501696': 1 },
+            querymask: { '681154064': 1, '3790501696': 2 },
+            querydist: { '681154064': 1, '3790501696': 0 }
+        });
+        assert.end();
+    });
+});
+
 

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -1,4 +1,5 @@
 var Cache = require('../index.js').Cache;
+var Relev = require('./relev');
 var tape = require('tape');
 var fs = require('fs');
 
@@ -25,14 +26,53 @@ tape('#phrasematchPhraseRelev', function(assert) {
             result: [ 1, 2 ],
             relevs: { '1': 8796118792011777, '2': 7353550946435074 }
         });
-        assert.equal((result.relevs[1]/Math.pow(2,48)|0) % Math.pow(2,5), 31, '1.relev');
-        assert.equal((result.relevs[1]/Math.pow(2,45)|0) % Math.pow(2,3), 2, '1.count');
-        assert.equal((result.relevs[1]/Math.pow(2,33)|0) % Math.pow(2,12), 3, '1.reason');
-        assert.equal((result.relevs[1]/Math.pow(2,0)|0) % Math.pow(2,32), 1, '1.id');
-        assert.equal((result.relevs[2]/Math.pow(2,48)|0) % Math.pow(2,5), 26, '2.relev');
-        assert.equal((result.relevs[2]/Math.pow(2,45)|0) % Math.pow(2,3), 1, '2.count');
-        assert.equal((result.relevs[2]/Math.pow(2,33)|0) % Math.pow(2,12), 2, '2.reason');
-        assert.equal((result.relevs[2]/Math.pow(2,0)|0) % Math.pow(2,32), 2, '2.id');
+        var r1 = new Relev(result.relevs[1]);
+        var r2 = new Relev(result.relevs[2]);
+        assert.equal(r1.relev, 1, '1.relev');
+        assert.equal(r1.count, 2, '1.count');
+        assert.equal(r1.reason, 3, '1.reason');
+        assert.equal(r1.id, 1, '1.id');
+        assert.equal(r2.relev, 0.8387096774193549, '2.relev');
+        assert.equal(r2.count, 1, '2.count');
+        assert.equal(r2.reason, 2, '2.reason');
+        assert.equal(r2.id, 2, '2.id');
+        assert.end();
+    });
+});
+
+tape('#phrasematchPhraseRelev', function(assert) {
+    var cache = new Cache('a', 0);
+    var phrases = [ 1, 2 ];
+    var queryidx = {
+        10000: 0,
+        20000: 1
+    };
+    var querymask = {
+        10000: 1 << 0,
+        20000: 1 << 1
+    };
+    var querydist = {
+        10000: 1,
+        20000: 1
+    };
+    cache._set('phrase', 0, 1, [10009,20006]);
+    cache._set('phrase', 0, 2, [20013,30002]);
+    cache.phrasematchPhraseRelev(phrases, queryidx, querymask, querydist, function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result, {
+            result: [ 1, 2 ],
+            relevs: { '1': 8514643815301121, '2': 7353550946435074 }
+        });
+        var r1 = new Relev(result.relevs[1]);
+        var r2 = new Relev(result.relevs[2]);
+        assert.equal(r1.relev, 0.967741935483871, '1.relev');
+        assert.equal(r1.count, 2, '1.count');
+        assert.equal(r1.reason, 3, '1.reason');
+        assert.equal(r1.id, 1, '1.id');
+        assert.equal(r2.relev, 0.8387096774193549, '2.relev');
+        assert.equal(r2.count, 1, '2.count');
+        assert.equal(r2.reason, 2, '2.reason');
+        assert.equal(r2.id, 2, '2.id');
         assert.end();
     });
 });


### PR DESCRIPTION
Fixes issue where phraseMatchDegens was always scoring degenerate terms with termdist = 0 due to a variable typo.

Adds tests for this case as well.