### PR TITLE
Repeated neighbor term phraseRelev fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.1.3",
+  "version": "0.1.4-chopsticks",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -77,7 +77,7 @@ tape('#phrasematchPhraseRelev', function(assert) {
     });
 });
 
-tape('#phrasematchPhraseRelev ("a a b")', function(assert) {
+tape('#phrasematchPhraseRelev (query: "a a b", phrase: "a b")', function(assert) {
     var cache = new Cache('a', 0);
     var phrases = [ 1 ];
     var queryidx = { 10000: 0, 20000: 2 };
@@ -100,7 +100,7 @@ tape('#phrasematchPhraseRelev ("a a b")', function(assert) {
     });
 });
 
-tape('#phrasematchPhraseRelev ("a a c b")', function(assert) {
+tape('#phrasematchPhraseRelev (query: "a a c b", phrase: "a b")', function(assert) {
     var cache = new Cache('a', 0);
     var phrases = [ 1 ];
     var queryidx = { 10000: 0, 20000: 3 };

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -77,4 +77,50 @@ tape('#phrasematchPhraseRelev', function(assert) {
     });
 });
 
+tape('#phrasematchPhraseRelev ("a a b")', function(assert) {
+    var cache = new Cache('a', 0);
+    var phrases = [ 1 ];
+    var queryidx = { 10000: 0, 20000: 2 };
+    var querymask = { 10000: (1 << 0) + (1 << 1), 20000: 1 << 2 };
+    var querydist = { 10000: 0, 20000: 0 };
+    cache._set('phrase', 0, 1, [10009,20006]);
+    cache.phrasematchPhraseRelev(phrases, queryidx, querymask, querydist, function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result.result, [1]);
+        assert.deepEqual(new Relev(result.relevs['1']), {
+            id: 1,
+            idx: 0,
+            tmpid: 1,
+            reason: 7,
+            count: 2,
+            relev: 1,
+            check: true
+        });
+        assert.end();
+    });
+});
+
+tape('#phrasematchPhraseRelev ("a a c b")', function(assert) {
+    var cache = new Cache('a', 0);
+    var phrases = [ 1 ];
+    var queryidx = { 10000: 0, 20000: 3 };
+    var querymask = { 10000: (1 << 0) + (1 << 1), 20000: 1 << 3 };
+    var querydist = { 10000: 0, 20000: 0 };
+    cache._set('phrase', 0, 1, [10009,20006]);
+    cache.phrasematchPhraseRelev(phrases, queryidx, querymask, querydist, function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result.result, [1]);
+        assert.deepEqual(new Relev(result.relevs['1']), {
+            id: 1,
+            idx: 0,
+            tmpid: 1,
+            reason: 3,
+            count: 1,
+            relev: 0.5806451612903226,
+            check: true
+        });
+        assert.end();
+    });
+});
+
 


### PR DESCRIPTION
            0     1  2  3
    query:  queen st st john
    phrase:       st    john

Currently, the relev for this phrase is calculated to be < 1 because it short circuits at the first `st` match. When the loop gets to john@3 it's found to be non-contiguous with the previous match for st@1.

The fix in this branch ditches using queryidx/lastidx (which only represents the index of the *first* occurrence of a term in a query) and instead looks for overlap between termmasks:

            0     1  2  3
    query:  queen st st john

    # masks go from RTL

    mask st:    0110
    mask john:  1000

When looking at `john`, the previous matched term's mask for `st` is shifted to the left 1 and &'d to find overlaps:

    mask st:    1100 <= shifted 1 bit to the left
    mask john:  1000

### Caveats

This approach leaves open the possibility of corner cases like this:

    query:  A B D B C
    phrase: A B C

    A is next to B and
    B is next to C but
    there is no contiguous occurrence of A B C

I'm ok with this for now -- let's burn that bridge if we ever get there.

### Next actions

- [x] Testing IRL
- [x] Merge and gogogo

cc @ingalls @sbma44 @karenzshea

------

*Why chopsticks? https://www.youtube.com/watch?v=DtvNAQ8KOqI*