### PR TITLE
Setrelev fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.2.0",
+  "version": "0.2.0-pushshove",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1301,8 +1301,10 @@ double _setRelevance(unsigned short queryLength, std::vector<SetRelev> & sets, s
             // Each db may contribute a distinct matching reason to the final
             // relev. If this entry is for a db that has already contributed
             // but without the same reason mark it as false.
-            if (lastgroup == groups[set.idx] && lastreason != set.reason) {
-                checkmask += 1<<i;
+            if (lastgroup == groups[set.idx]) {
+                if (lastreason != set.reason) {
+                    checkmask += 1<<i;
+                }
                 continue;
             }
 

--- a/test/setRelevance.test.js
+++ b/test/setRelevance.test.js
@@ -142,5 +142,24 @@ test('setRelevance', function(t) {
         sets: [ stack[0], stack[1] ]
     }, 'elements with an early reason cannot seek backwards to match an earlier term');
 
+    stack = [
+        Relev.encode({ id: 2064953, idx: 2, tmpid: 2202064953, reason: 14, count: 2, relev: 1, check: true }),
+        Relev.encode({ id: 18537894, idx: 1, tmpid: 2118537894, reason: 14, count: 2, relev: 1, check: true }),
+        Relev.encode({ id: 11566, idx: 0, tmpid: 1400011566, reason: 10, count: 1, relev: 1, check: true }),
+    ];
+    t.deepEqual(setRelevance(4, stack, [0,1,1]), {
+        relevance: 0.75,
+        sets: stack.slice(0,3)
+    }, 'real: merrick rd merrick (with city)');
+
+    stack = [
+        Relev.encode({ id: 2064953, idx: 2, tmpid: 2202064953, reason: 14, count: 2, relev: 1, check: true }),
+        Relev.encode({ id: 18537894, idx: 1, tmpid: 2118537894, reason: 14, count: 2, relev: 1, check: true }),
+    ];
+    t.deepEqual(setRelevance(4, stack, [0,1,1]), {
+        relevance: 0.5,
+        sets: stack.slice(0,2)
+    }, 'real: merrick rd merrick (no city)');
+
     t.end();
 });


### PR DESCRIPTION
Fixes a bug where multiple relevs matching the same query reason from the same group could be counted multiple times. Adds tests for this case as well.