### PR TITLE
Allow gappy queries [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.2.1",
+  "version": "0.2.1-dev",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.2.1-dev",
+  "version": "0.2.1-youNeverKnow",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -934,6 +934,10 @@ void _phrasematchPhraseRelev(uv_work_t* req) {
                 it = baton->querydist.find(term);
                 unsigned short termdist = it->second;
 
+                //If there is gap between the current termmask
+                // and the last termmask then it means that the query
+                //has extra input ie: Query(a d c)  to find (a b c)
+                //This adds a penalty to these gaps
                 if (lastmask < termmask && lastmask != 0) {
                     while (!(termmask & (lastmask << 1))) {
                         relevPenalty += 0.10;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -955,6 +955,7 @@ void _phrasematchPhraseRelev(uv_work_t* req) {
         // get relev back to float-land.
         relev = relev / total - relevPenalty;
         relev = (relev > 0.99 ? 1 : relev) - (chardist * 0.01);
+        if (relev < 0) relev = 0;
 
         if (relev > max_relev) {
             max_relev = relev;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -924,7 +924,7 @@ void _phrasematchPhraseRelev(uv_work_t* req) {
                 relevPenaltyCount++;
             } else {
                 if (relevPenaltyCount > 0) {
-                    relevPenalty += relevPenaltyCount * 0.10;
+                    relevPenalty += relevPenaltyCount * 0.01;
                     lastmask = lastmask << relevPenaltyCount;
                     relevPenaltyCount = 0;
                 }

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -114,8 +114,8 @@ tape('#phrasematchPhraseRelev (query: "a a c b", phrase: "a b")', function(asser
             id: 1,
             idx: 0,
             tmpid: 1,
-            reason: 3,
-            count: 1,
+            reason: 11,
+            count: 2,
             relev: 0.5806451612903226,
             check: true
         });
@@ -124,3 +124,27 @@ tape('#phrasematchPhraseRelev (query: "a a c b", phrase: "a b")', function(asser
 });
 
 
+tape('#phrasematchPhraseRelev (query: "a c", phrase: "a b c")', function(assert) {
+    var cache = new Cache('a', 0);
+    var phrases = [ 1 ];
+
+    //Position of terms in index
+    var queryidx = { 10000: 0, 30000: 1 };
+    var querymask = { 10000: 1, 2000: 0, 30000: 1 << 2 };
+    var querydist = { 10000: 0, 30000: 0 };
+    cache._set('phrase', 0, 1, [10009,20009,30009]);
+    cache.phrasematchPhraseRelev(phrases, queryidx, querymask, querydist, function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result.result, [1]);
+        assert.deepEqual(new Relev(result.relevs['1']), {
+            id: 1,
+            idx: 0,
+            tmpid: 1,
+            reason: 5,
+            count: 2,
+            relev: 0.5483870967741935,
+            check: true
+        });
+        assert.end();
+    });
+});

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -147,3 +147,46 @@ tape('#phrasematchPhraseRelev (query: "a c", phrase: "a b c")', function(assert)
         assert.end();
     });
 });
+
+// Queries that have extraneous terms are penalized 0.10 for each term
+tape('#phrasematchPhraseRelev (query: "a c d e f g b", phrase: "a b")', function(assert) {
+    var cache = new Cache('a', 0);
+    var phrases = [ 1 ];
+
+    //Position of terms in index
+    var queryidx = { 10000: 0, 20000: 6 };
+    var querymask = { 10000: 1, 20000: 1 << 6, 30000: 0, 40000: 0, 50000: 0, 60000: 0, 70000: 0 };
+    var querydist = { 10000: 0, 20000: 0 };
+    cache._set('phrase', 0, 1, [10009,20009]);
+    cache.phrasematchPhraseRelev(phrases, queryidx, querymask, querydist, function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result.result, [1]);
+        assert.deepEqual(new Relev(result.relevs['1']), {
+            id: 1,
+            idx: 0,
+            tmpid: 1,
+            reason: 65,
+            count: 2,
+            relev: 0.4838709677419355,
+            check: true
+        });
+        assert.end();
+    });
+});
+
+// Negative relevs should fail gracefully (This produces a relev of -415.250000)
+tape('#phrasematchPhraseRelev (query: "a c", phrase: "a b c d e")', function(assert) {
+    var cache = new Cache('a', 0);
+    var phrases = [ 1 ];
+
+    //Position of terms in index
+    var queryidx = { 10000: 0, 30000: 2 };
+    var querymask = { 10000: 1, 20000: 0, 30000: 1 << 2, 40000: 0, 50000: 0 };
+    var querydist = { 10000: 0, 30000: 0 };
+    cache._set('phrase', 0, 1, [10009,20009,30009,40009,50009]);
+    cache.phrasematchPhraseRelev(phrases, queryidx, querymask, querydist, function(err, result) {
+        assert.ifError(err);
+        assert.deepEqual(result.result, []);
+        assert.end();
+    });
+});

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -116,13 +116,12 @@ tape('#phrasematchPhraseRelev (query: "a a c b", phrase: "a b")', function(asser
             tmpid: 1,
             reason: 11,
             count: 2,
-            relev: 0.5806451612903226,
+            relev: 0.8709677419354839,
             check: true
         });
         assert.end();
     });
 });
-
 
 tape('#phrasematchPhraseRelev (query: "a c", phrase: "a b c")', function(assert) {
     var cache = new Cache('a', 0);

--- a/test/phrasematchPhraseRelev.test.js
+++ b/test/phrasematchPhraseRelev.test.js
@@ -141,7 +141,7 @@ tape('#phrasematchPhraseRelev (query: "a c", phrase: "a b c")', function(assert)
             tmpid: 1,
             reason: 5,
             count: 2,
-            relev: 0.5483870967741935,
+            relev: 0.6451612903225806,
             check: true
         });
         assert.end();


### PR DESCRIPTION
## Overview

If there is an index object of the form `a b c` and a query of `a c`, no results will be returned. At the moment if this was enabled, an index object of `a b c d e f ....` and a query of `a z` would return a relevance of 1. This PR enables gappy queries but adds a `0.10` penalty to the relev for each token that is missed.

## Todo
- [x] Test with carmen
- [ ] Test against a large list of addresses

## Tests

### Carmen-Cache Tests

Carmen-Cache tests currently pass with the exception of [`a a c b`](https://github.com/mapbox/carmen-cache/blob/master/test/phrasematchPhraseRelev.test.js#L103-L124). Since this is a one token gappy query, the change in relev from `~0.60` to `~0.90` is expected.

### Carmen Tests

Carmen tests with this branch currently pass with the exception of [weird address](https://github.com/mapbox/carmen/blob/ad4508469282ec16343de6e1241b796af70400ff/test/geocode-unit.test.js#L572-L581). Since this is a 'gappy' query, this is expected. More testing will be needed to see if this will negatively impact results.
