### PR TITLE
Allow arbitrary order in setrelevance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.4.0",
+  "version": "0.4.1-backy1",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.4.1-backy1",
+  "version": "0.4.1-backy2",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/test/setRelevance.test.js
+++ b/test/setRelevance.test.js
@@ -160,5 +160,14 @@ test('setRelevance', function(t) {
         sets: stack.slice(1,2)
     }, 'query: trinidad and tobago, stack: trinidad, trinidad and tobago');
 
+    stack = [
+        Relev.encode({ id: 1, idx: 1, tmpid: 1, reason: 2, count: 1, relev: 1, check: true }),
+        Relev.encode({ id: 1, idx: 0, tmpid: 2, reason: 1, count: 1, relev: 1, check: true }),
+    ];
+    t.deepEqual(setRelevance(2, stack, [0,1]), {
+        relevance: 0.75,
+        sets: stack.slice(0,2)
+    }, 'query: b a, stack: a b (backy penalty)');
+
     t.end();
 });


### PR DESCRIPTION
Previously:

    query: c a b
    stack: a b c

Would score at best the `a b` portion of the stack.

Now:

    query: c a b
    stack: a b c

Full marks for `a b`, half marks for `c` since it goes "backwards" to the query flow to match.