### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,5 +69,5 @@ script:
 - npm test
 
 after_success:
-- if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude build/Release/obj/gen --exclude src/binding.hpp > /dev/null; fi;
+- if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude ./mason_packages --exclude src/pbf.hpp --exclude ./deps --exclude build/Release/obj/gen --exclude src/binding.hpp > /dev/null; fi;
 - if [[ ${COVERAGE} != true ]]; then ./test/travis-publish.sh; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ before_install:
 install:
  - if [[ ${COVERAGE} == true ]]; then
      PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls;
-     export CXXFLAGS="--coverage ${CXXFLAGS}"
-     export LDFLAGS="--coverage ${LDFLAGS}"
+     export CXXFLAGS="--coverage ${CXXFLAGS}";
+     export LDFLAGS="--coverage ${LDFLAGS}";
    fi
  - npm install --build-from-source --clang=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
 
 matrix:
   include:
+     # Coverage
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="0.10.38" COVERAGE=true
      # Linux
      - os: linux
        compiler: clang
@@ -34,9 +38,13 @@ env:
    - secure: lmfuNtK0/ubV4ZZobgfeKY6DzG41ZciS4a00yCe29jHLxAg+EEmB/qpsW5d1//cC94OKsAySW08xp2uX5wBVvtryaaoiwU7fdKF9DOxHRHieGw/3+m8NNjELkd5hKMKiqDj7l4QPMchzBQR2PQkoG0UMCGUFe+RmzZ2/iCdGHXU=
 
 before_install:
+ - export COVERAGE=${COVERAGE:-false}
  - if [[ $(uname -s) == 'Linux' ]]; then
      export CXX="clang++-3.5";
      export CC="clang-3.5";
+     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;
+   else
+     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages;
    fi;
  - source ./test/install_node.sh ${NODE_VERSION}
  - export PATH=./node_modules/.bin/:$PATH
@@ -50,10 +58,16 @@ before_install:
  - export LDFLAGS="-L$(pwd)/mason_packages/.link/lib"
 
 install:
-- npm install --build-from-source --clang=1
+ - if [[ ${COVERAGE} == true ]]; then
+     PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls;
+     export CXXFLAGS="--coverage ${CXXFLAGS}"
+     export LDFLAGS="--coverage ${LDFLAGS}"
+   fi
+ - npm install --build-from-source --clang=1
 
 script:
 - npm test
 
 after_success:
-- ./test/travis-publish.sh
+- if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude build/Release/obj/gen --exclude src/binding.hpp; fi;
+- if [[ ${COVERAGE} != true ]]; then ./test/travis-publish.sh; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,5 +69,5 @@ script:
 - npm test
 
 after_success:
-- if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude build/Release/obj/gen --exclude src/binding.hpp; fi;
+- if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude build/Release/obj/gen --exclude src/binding.hpp > /dev/null; fi;
 - if [[ ${COVERAGE} != true ]]; then ./test/travis-publish.sh; fi;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/mapbox/carmen-cache.svg)](https://travis-ci.org/mapbox/carmen-cache)
 [![Coverity](https://scan.coverity.com/projects/5667/badge.svg)](https://scan.coverity.com/projects/5667)
+[![Coverage Status](https://coveralls.io/repos/mapbox/carmen-cache/badge.svg)](https://coveralls.io/r/mapbox/carmen-cache)
 
 carmen-cache
 ------------


### PR DESCRIPTION
 - instruments the binaries with `--coverage`
 - running the tests then dumps coverage files
 - cpp-coveralls finds 'em and pushes to coveralls.io
 - per commit coverage report then viewable at https://coveralls.io/r/mapbox/carmen-cache