### PR TITLE
Use 32 bit keys

### DIFF
--- a/proto/index.proto
+++ b/proto/index.proto
@@ -6,7 +6,7 @@ option optimize_for = LITE_RUNTIME;
 message object {
 
     message item {
-        required int64 key = 1;
+        required uint32 key = 1;
         repeated int64 val = 2 [ packed = true ];
     }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -228,7 +228,7 @@ NAN_METHOD(Cache::pack)
                 }
                 for (auto const& item : litr->second) {
                     ::carmen::proto::object_item * new_item = message.add_items();
-                    new_item->set_key(static_cast<int64_t>(item.first));
+                    new_item->set_key(item.first);
                     unsigned start = (item.second & 0xffffffff);
                     unsigned len = (item.second >> 32);
                     std::string ref = mitr->second.substr(start,len);
@@ -402,7 +402,7 @@ void load_into_cache(Cache::larraycache & larrc,
                     //  - libstdc++ does not support std::map::emplace <-- does now with gcc 4.8, but...
                     //  - we are using google::sparshash now, which does not support emplace (yet?)
                     //  - larrc.emplace(buffer.varint(),Cache::string_ref_type(message.getData(),len)) was not faster on OS X
-                    Cache::offset_type offsets = (((Cache::offset_type)len << 32)) | (((Cache::offset_type)start) & 0xffffffff);
+                    Cache::value_type offsets = (((Cache::value_type)len << 32)) | (((Cache::value_type)start) & 0xffffffff);
                     larrc.insert(std::make_pair(key_id,offsets));
                 }
                 // it is safe to break immediately because tag 1 should come first

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -36,15 +36,15 @@ protected:
 class Cache: public node::ObjectWrap {
 public:
     ~Cache();
-    typedef uint64_t int_type;
+    typedef uint32_t key_type;
+    typedef uint64_t value_type;
     // lazy ref item
-    typedef uint64_t offset_type;
-    typedef google::sparse_hash_map<int_type,offset_type> larraycache;
+    typedef google::sparse_hash_map<uint32_t,value_type> larraycache;
     typedef std::map<std::string,larraycache> lazycache;
     typedef std::map<std::string,std::string> message_cache;
     // fully cached item
-    typedef std::vector<int_type> intarray;
-    typedef std::map<uint32_t,intarray> arraycache;
+    typedef std::vector<value_type> intarray;
+    typedef std::map<key_type,intarray> arraycache;
     typedef std::map<std::string,arraycache> memcache;
     static v8::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Handle<v8::Object> target);


### PR DESCRIPTION
My understanding is that keys are intended to be 32 bit unsigned int (based on reviewing https://github.com/mapbox/carmen#index-structure). However the code has been using 64 bit in a few places when this is unneeded. All tests pass with this change which indicates the `index.proto` change is harmless, but this should be further tested.