### PR TITLE
[c4] dict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.5.0-dict1",
+  "version": "0.5.0-dict2",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.5.0-dev8",
+  "version": "0.5.0-dict1",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -118,44 +118,15 @@ Cache::intarray __get(Cache const* c, std::string const& type, std::string const
     }
 }
 
-bool __exists(Cache const* c, std::string const& type, std::string const& shard, uint32_t id) {
+bool __dict(Cache const* c, std::string const& type, std::string const& shard, uint32_t id) {
     std::string key = type + "-" + shard;
-    Cache::memcache const& mem = c->cache_;
-    Cache::memcache::const_iterator itr = mem.find(key);
-    if (itr == mem.end()) {
-        Cache::lazycache const& lazy = c->lazy_;
-        Cache::lazycache::const_iterator litr = lazy.find(key);
-        if (litr == lazy.end()) {
-            return false;
-        }
-        Cache::message_cache const& messages = c->msg_;
-        Cache::message_cache::const_iterator mitr = messages.find(key);
-        if (mitr == messages.end()) {
-            throw std::runtime_error("misuse");
-        }
-        Cache::larraycache::const_iterator laitr = litr->second.find(id);
-        if (laitr == litr->second.end()) {
-            return false;
-        }
-        // NOTE: we cannot call array.reserve here since
-        // the total length is not known
-        unsigned start = (laitr->second & 0xffffffff);
-        unsigned len = (laitr->second >> 32);
-        std::string ref = mitr->second.substr(start,len);
-        protobuf::message buffer(ref.data(), ref.size());
-        while (buffer.next()) {
-            if (buffer.tag == 1) {
-                return true;
-            } else {
-                std::stringstream msg("");
-                msg << "cxx get: hit unknown protobuf type: '" << buffer.tag << "'";
-                throw std::runtime_error(msg.str());
-            }
-        }
+    Cache::dictcache const& dict = c->dict_;
+    Cache::dictcache::const_iterator itr = dict.find(key);
+    if (itr == dict.end()) {
         return false;
     } else {
-        Cache::arraycache::const_iterator aitr = itr->second.find(id);
-        return aitr != itr->second.end();
+        Cache::ldictcache::const_iterator ditr = itr->second.find(id);
+        return ditr != itr->second.end();
     }
 }
 
@@ -167,11 +138,12 @@ void Cache::Initialize(Handle<Object> target) {
     NODE_SET_PROTOTYPE_METHOD(t, "has", has);
     NODE_SET_PROTOTYPE_METHOD(t, "load", load);
     NODE_SET_PROTOTYPE_METHOD(t, "loadSync", loadSync);
+    NODE_SET_PROTOTYPE_METHOD(t, "loadAsDict", loadAsDict);
     NODE_SET_PROTOTYPE_METHOD(t, "pack", pack);
     NODE_SET_PROTOTYPE_METHOD(t, "list", list);
     NODE_SET_PROTOTYPE_METHOD(t, "_set", _set);
     NODE_SET_PROTOTYPE_METHOD(t, "_get", _get);
-    NODE_SET_PROTOTYPE_METHOD(t, "_exists", _exists);
+    NODE_SET_PROTOTYPE_METHOD(t, "_dict", _dict);
     NODE_SET_PROTOTYPE_METHOD(t, "unload", unload);
     NODE_SET_METHOD(t, "coalesce", coalesce);
     target->Set(NanNew("Cache"),t->GetFunction());
@@ -384,6 +356,28 @@ NAN_METHOD(Cache::_set)
     NanReturnUndefined();
 }
 
+void load_into_dict(Cache::ldictcache & ldict, const char * data, size_t size) {
+    protobuf::message message(data,size);
+    while (message.next()) {
+        if (message.tag == 1) {
+            uint64_t len = message.varint();
+            protobuf::message buffer(message.getData(), static_cast<std::size_t>(len));
+            while (buffer.next()) {
+                if (buffer.tag == 1) {
+                    uint64_t key_id = buffer.varint();
+                    ldict.insert(key_id);
+                }
+                break;
+            }
+            message.skipBytes(len);
+        } else {
+            std::stringstream msg("");
+            msg << "load: hit unknown protobuf type: '" << message.tag << "'";
+            throw std::runtime_error(msg.str());
+        }
+    }
+}
+
 void load_into_cache(Cache::larraycache & larrc,
                             const char * data,
                             size_t size) {
@@ -461,6 +455,45 @@ NAN_METHOD(Cache::loadSync)
             messages.emplace(key,std::string(node::Buffer::Data(obj),node::Buffer::Length(obj)));
         }
         load_into_cache(c->lazy_[key],node::Buffer::Data(obj),node::Buffer::Length(obj));
+    } catch (std::exception const& ex) {
+        return NanThrowTypeError(ex.what());
+    }
+    NanReturnUndefined();
+}
+
+NAN_METHOD(Cache::loadAsDict)
+{
+    NanScope();
+    if (args.Length() < 2) {
+        return NanThrowTypeError("expected at three args: 'buffer', 'type', and 'shard'");
+    }
+    if (!args[0]->IsObject()) {
+        return NanThrowTypeError("first argument must be a Buffer");
+    }
+    Local<Object> obj = args[0]->ToObject();
+    if (obj->IsNull() || obj->IsUndefined()) {
+        return NanThrowTypeError("a buffer expected for first argument");
+    }
+    if (!node::Buffer::HasInstance(obj)) {
+        return NanThrowTypeError("first argument must be a Buffer");
+    }
+    if (!args[1]->IsString()) {
+        return NanThrowTypeError("second arg 'type' must be a String");
+    }
+    if (!args[2]->IsNumber()) {
+        return NanThrowTypeError("third arg 'shard' must be an Integer");
+    }
+    try {
+        std::string type = *String::Utf8Value(args[1]->ToString());
+        std::string shard = *String::Utf8Value(args[2]->ToString());
+        std::string key = type + "-" + shard;
+        Cache* c = node::ObjectWrap::Unwrap<Cache>(args.This());
+        Cache::dictcache & dict = c->dict_;
+        Cache::dictcache::iterator ditr = dict.find(key);
+        if (ditr == dict.end()) {
+            c->dict_.emplace(key,Cache::ldictcache());
+        }
+        load_into_dict(c->dict_[key],node::Buffer::Data(obj),node::Buffer::Length(obj));
     } catch (std::exception const& ex) {
         return NanThrowTypeError(ex.what());
     }
@@ -641,7 +674,7 @@ NAN_METHOD(Cache::_get)
     }
 }
 
-NAN_METHOD(Cache::_exists)
+NAN_METHOD(Cache::_dict)
 {
     NanScope();
     if (args.Length() < 3) {
@@ -661,7 +694,7 @@ NAN_METHOD(Cache::_exists)
         std::string shard = *String::Utf8Value(args[1]->ToString());
         uint32_t id = static_cast<uint32_t>(args[2]->IntegerValue());
         Cache* c = node::ObjectWrap::Unwrap<Cache>(args.This());
-        bool exists = __exists(c, type, shard, id);
+        bool exists = __dict(c, type, shard, id);
         NanReturnValue(NanNew<Boolean>(exists));
     } catch (std::exception const& ex) {
         return NanThrowTypeError(ex.what());

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include "index.pb.h"
 #include <sparsehash/sparse_hash_map>
+#include <sparsehash/sparse_hash_set>
 #pragma clang diagnostic pop
 #include <iostream>
 
@@ -40,17 +41,20 @@ public:
     typedef uint64_t value_type;
     // lazy ref item
     typedef google::sparse_hash_map<uint32_t,value_type> larraycache;
+    typedef google::sparse_hash_set<uint32_t> ldictcache;
     typedef std::map<std::string,larraycache> lazycache;
     typedef std::map<std::string,std::string> message_cache;
     // fully cached item
     typedef std::vector<value_type> intarray;
     typedef std::map<key_type,intarray> arraycache;
     typedef std::map<std::string,arraycache> memcache;
+    typedef std::map<std::string,ldictcache> dictcache;
     static v8::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Handle<v8::Object> target);
     static NAN_METHOD(New);
     static NAN_METHOD(has);
     static NAN_METHOD(loadSync);
+    static NAN_METHOD(loadAsDict);
     static NAN_METHOD(load);
     static void AsyncLoad(uv_work_t* req);
     static void AfterLoad(uv_work_t* req);
@@ -58,7 +62,7 @@ public:
     static NAN_METHOD(list);
     static NAN_METHOD(_get);
     static NAN_METHOD(_set);
-    static NAN_METHOD(_exists);
+    static NAN_METHOD(_dict);
     static NAN_METHOD(unload);
     static NAN_METHOD(coalesce);
     static void AsyncRun(uv_work_t* req);
@@ -67,6 +71,7 @@ public:
     void _ref() { Ref(); }
     void _unref() { Unref(); }
     memcache cache_;
+    dictcache dict_;
     lazycache lazy_;
     message_cache msg_;
 };

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -53,6 +53,7 @@ public:
     static void Initialize(v8::Handle<v8::Object> target);
     static NAN_METHOD(New);
     static NAN_METHOD(has);
+    static NAN_METHOD(hasDict);
     static NAN_METHOD(loadSync);
     static NAN_METHOD(loadAsDict);
     static NAN_METHOD(load);

--- a/test/cache.bench.test.js
+++ b/test/cache.bench.test.js
@@ -13,14 +13,27 @@ tape('setup', function(assert) {
     });
 });
 
-tape('bench load', function(assert) {
+tape('bench loadSync', function(assert) {
     var cache = new Cache('a');
     var time = +new Date;
-    // for (var i = 0; i < 256; i++) cache.loadSync(data, 'stat', i);
+    var mem = process.memoryUsage().rss;
+    for (var i = 0; i < 256; i++) cache.loadSync(data, 'stat', i);
+    time = (+new Date - time);
+    mem = process.memoryUsage().rss - mem;
+    assert.equal(time < 80e3, true, 'loadSync x256 took ' + time + 'ms');
+    assert.equal(mem < 1e9, true, 'loadSync rss + ' + mem + ' bytes');
+    assert.end();
+});
+
+tape('bench loadAsDict', function(assert) {
+    var cache = new Cache('a');
+    var time = +new Date;
+    var mem = process.memoryUsage().rss;
     for (var i = 0; i < 256; i++) cache.loadAsDict(data, 'stat', i);
     time = (+new Date - time);
+    mem = process.memoryUsage().rss - mem;
     assert.equal(time < 80e3, true, 'loadAsDict x256 took ' + time + 'ms');
-    console.log(process.memoryUsage());
+    assert.equal(mem < 1e9, true, 'loadAsDict rss + ' + mem + ' bytes');
     assert.end();
 });
 

--- a/test/cache.bench.test.js
+++ b/test/cache.bench.test.js
@@ -16,9 +16,10 @@ tape('setup', function(assert) {
 tape('bench load', function(assert) {
     var cache = new Cache('a');
     var time = +new Date;
-    for (var i = 0; i < 256; i++) cache.loadSync(data, 'stat', i);
+    // for (var i = 0; i < 256; i++) cache.loadSync(data, 'stat', i);
+    for (var i = 0; i < 256; i++) cache.loadAsDict(data, 'stat', i);
     time = (+new Date - time);
-    assert.equal(time < 80e3, true, 'load x256 took ' + time + 'ms');
+    assert.equal(time < 80e3, true, 'loadAsDict x256 took ' + time + 'ms');
     console.log(process.memoryUsage());
     assert.end();
 });

--- a/test/cache.bench.test.js
+++ b/test/cache.bench.test.js
@@ -21,7 +21,7 @@ tape('bench loadSync', function(assert) {
     time = (+new Date - time);
     mem = process.memoryUsage().rss - mem;
     assert.equal(time < 80e3, true, 'loadSync x256 took ' + time + 'ms');
-    assert.equal(mem < 1e9, true, 'loadSync rss + ' + mem + ' bytes');
+    assert.equal(mem < 2e9, true, 'loadSync rss + ' + mem + ' bytes');
     assert.end();
 });
 

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -35,16 +35,6 @@ var fs = require('fs');
             assert.end();
         });
 
-
-        tape('#exists', function(assert) {
-            var cache = new Cache('a', 1);
-            assert.equal(cache._exists('term', 0, 5), false);
-            cache._set('term', 0, 5, [0,1,2]);
-            assert.equal(cache._exists('term', 0, 5), true);
-            assert.equal(cache._exists('term', 0, 6), false);
-            assert.end();
-        });
-
         tape('#pack', function(assert) {
             var cache = new Cache('a', 1);
             cache._set('term', 0, 5, [0,1,2]);
@@ -93,6 +83,20 @@ var fs = require('fs');
             assert.deepEqual([5,6], loader._get('term', 0, 21));
             assert.deepEqual([0], loader.list('term'), 'single shard');
             assert.deepEqual(['5', '21'], loader.list('term', 0), 'keys in shard');
+            assert.end();
+        });
+
+        tape('#dict', function(assert) {
+            var cache = new Cache('a');
+            cache._set('term', 0, 5, [0,1,2]);
+            cache._set('term', 0, 21, [5,6]);
+            var pack = cache.pack('term', 0);
+
+            var loader = new Cache('b');
+            loader.loadAsDict(pack, 'term', 0);
+            assert.deepEqual(loader._dict('term', 0, 5), true);
+            assert.deepEqual(loader._dict('term', 0, 21), true);
+            assert.deepEqual(loader._dict('term', 0, 22), false);
             assert.end();
         });
 

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -88,15 +88,29 @@ var fs = require('fs');
 
         tape('#dict', function(assert) {
             var cache = new Cache('a');
-            cache._set('term', 0, 5, [0,1,2]);
-            cache._set('term', 0, 21, [5,6]);
-            var pack = cache.pack('term', 0);
+            cache._set('term', 0, 5, []);
+            cache._set('term', 0, 21, []);
+            cache._set('term', 0, 899688358, []);
+            cache._set('term', 1, 4, []);
+            cache._set('term', 1, 91231, []);
+            cache._set('term', 1, 8, []);
 
             var loader = new Cache('b');
-            loader.loadAsDict(pack, 'term', 0);
+
+            assert.deepEqual(loader.hasDict('term', 0), false);
+            loader.loadAsDict(cache.pack('term', 0), 'term', 0);
+            assert.deepEqual(loader.hasDict('term', 0), true);
             assert.deepEqual(loader._dict('term', 0, 5), true);
             assert.deepEqual(loader._dict('term', 0, 21), true);
             assert.deepEqual(loader._dict('term', 0, 22), false);
+            assert.deepEqual(loader._dict('term', 0, 899688358), true);
+
+            assert.deepEqual(loader.hasDict('term', 1), false);
+            assert.deepEqual(loader._dict('term', 1, 4), false);
+            loader.loadAsDict(cache.pack('term', 1), 'term', 1);
+            assert.deepEqual(loader.hasDict('term', 1), true);
+            assert.deepEqual(loader._dict('term', 1, 4), true);
+
             assert.end();
         });
 


### PR DESCRIPTION
Background: carmen is using the `stat` index as a fast "does this key exist" lookup to save on i/o when there's no grid to be loaded from a shard anyway. This was previously implemented using the same type of cache + the `_exists` check to save on parsing the protobuf message fully.

This PR switches to:

- Using `sparse_hash_set` as a dictionary for doing this check,
- Alternatively loading a PBF into this second dictionary cache using `loadAsDict()`
- Looking up a dictionary value from a shard using the `_dict()` method

------

What `test/cache.bench.test.js` has to say about this:

*c4*

```
# bench load
ok 3 load x256 took 29704ms
{ rss: 1058058240, heapTotal: 7195904, heapUsed: 3495056 }
```

*c4-dict*

```
# bench load
ok 3 loadAsDict x256 took 19397ms
{ rss: 233611264, heapTotal: 7195904, heapUsed: 3499864 
```