### PR TITLE
Sort covers

### DIFF
--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -238,6 +238,59 @@ test('coalesce args', function(assert) {
     });
 })();
 
+(function() {
+    var a = new Cache('a', 0);
+    var b = new Cache('b', 0);
+    a._set('grid', 0, 1, [
+        Grid.encode({
+            id: 1,
+            x: 1,
+            y: 1,
+            relev: 0.8,
+            score: 1
+        }),
+        Grid.encode({
+            id: 2,
+            x: 1,
+            y: 1,
+            relev: 1,
+            score: 1
+        }),
+    ]);
+    b._set('grid', 0, 1, [
+        Grid.encode({
+            id: 3,
+            x: 2,
+            y: 2,
+            relev: 1,
+            score: 1
+        }),
+    ]);
+    test('coalesceMulti (higher relev wins)', function(assert) {
+        coalesce([{
+            cache: a,
+            idx: 0,
+            zoom: 1,
+            weight: 0.5,
+            phrase: 1
+        }, {
+            cache: b,
+            idx: 1,
+            zoom: 2,
+            weight: 0.5,
+            phrase: 1
+        }], {}, function(err, res) {
+            assert.ifError(err);
+            // sorts by relev, score
+            assert.deepEqual(res.length, 1, '1 result');
+            assert.deepEqual(res[0].relev, 1, '0.relev');
+            assert.deepEqual(res[0].length, 2, '0.length');
+            assert.deepEqual(res[0][0], { distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, tmpid: 33554435, x: 2, y: 2 }, '0.0');
+            assert.deepEqual(res[0][1], { distance: 0, id: 2, idx: 0, relev: 0.5, score: 1, tmpid: 2, x: 1, y: 1 }, '0.1');
+            assert.end();
+        });
+    });
+})();
 
 // Multi sandwich scenario
 (function() {


### PR DESCRIPTION
Sort covers at coalesce, preferring ones with higher relevance to those with lower.

Stopgap until implementing coalesced stacking of permutations. https://github.com/mapbox/carmen/issues/295