### PR TITLE
switch to only storing 32 bits of the 64-bit hashes in the ldict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.9.0",
+  "version": "0.9.0-32bitcache1",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -9,6 +9,9 @@
 
 namespace carmen {
 
+/* use only the 32 least significant bits (should it be most significant? does it matter?) */
+#define trunc_hash(id) static_cast<uint32_t>(id & 0xffffffff)
+
 using namespace v8;
 
 Persistent<FunctionTemplate> Cache::constructor;
@@ -158,7 +161,7 @@ bool __dict(Cache const* c, std::string const& type, std::string const& shard, u
     if (itr == dict.end()) {
         return false;
     } else {
-        Cache::ldictcache::const_iterator ditr = itr->second.find(id);
+        Cache::ldictcache::const_iterator ditr = itr->second.find(trunc_hash(id));
         return ditr != itr->second.end();
     }
 }
@@ -212,7 +215,7 @@ NAN_METHOD(Cache::pack)
         carmen::proto::object message;
         if (itr != mem.end()) {
             for (auto const& item : itr->second) {
-                ::carmen::proto::object_item * new_item = message.add_items(); 
+                ::carmen::proto::object_item * new_item = message.add_items();
                 new_item->set_key(item.first);
                 Cache::intarray varr = item.second;
 
@@ -393,7 +396,7 @@ void load_into_dict(Cache::ldictcache & ldict, const char * data, size_t size) {
             while (buffer.next()) {
                 if (buffer.tag == 1) {
                     uint64_t key_id = static_cast<uint64_t>(buffer.varint());
-                    ldict.insert(key_id);
+                    ldict.insert(trunc_hash(key_id));
                 }
                 break;
             }

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -40,7 +40,7 @@ public:
     typedef uint64_t key_type;
     typedef uint64_t value_type;
     // pbf message cache
-    typedef google::sparse_hash_set<uint64_t> ldictcache;
+    typedef google::sparse_hash_set<uint32_t> ldictcache;
     // list + map as simple LRU cache
     typedef std::pair<std::string,std::string> message_pair;
     typedef std::list<message_pair> message_list;


### PR DESCRIPTION
This does what was proposed in #40 and switches the internal representation of the ldict to 32 bits. The external interface is unchanged, but only the 32 least significant bits of the 64-bit input hash are used.

Running the French address test, peak memory usage is down about 35%, from ~5.5 gigs to ~3.4 over the test run. The number of positives at this loop:

https://github.com/mapbox/carmen/blob/master/lib/phrasematch.js#L54

increased by 3, from 9049 to 9052, so, a tiny fraction of a percent, with no appreciable difference to either compute time or results over this test.

So... I think it works?

cc @mapbox/geocoding-gang