### PR TITLE
Upgrade to protozero 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "nan": "~2.2.0",
     "node-pre-gyp": "~0.6.19",
-    "protozero": "~1.2.3"
+    "protozero": "~1.3.0"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -105,9 +105,9 @@ Cache::intarray __get(Cache const* c, std::string const& type, std::string const
 
         std::string ref = cacheGet(c, key);
         protozero::pbf_reader message(ref);
-        while (message.next(1)) {
+        while (message.next(CACHE_MESSAGE)) {
             protozero::pbf_reader item = message.get_message();
-            while (item.next(1)) {
+            while (item.next(CACHE_ITEM)) {
                 uint64_t key_id = item.get_uint64();
                 if (key_id != id) break;
                 item.next();
@@ -375,9 +375,9 @@ NAN_METHOD(Cache::_set)
 
 void load_into_dict(Cache::ldictcache & ldict, const char * data, size_t size) {
     protozero::pbf_reader message(data,size);
-    while (message.next(1)) {
+    while (message.next(CACHE_MESSAGE)) {
         protozero::pbf_reader item = message.get_message();
-        if (item.next(1)) {
+        if (item.next(CACHE_ITEM)) {
             uint64_t key_id = item.get_uint64();
             ldict.insert(trunc_hash(key_id));
         }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -107,8 +107,7 @@ Cache::intarray __get(Cache const* c, std::string const& type, std::string const
         protozero::pbf_reader message(ref);
         while (message.next(1)) {
             protozero::pbf_reader item = message.get_message();
-            while (item.next()) {
-                if (item.tag() != 1) break;
+            while (item.next(1)) {
                 uint64_t key_id = item.get_uint64();
                 if (key_id != id) break;
                 item.next();
@@ -384,10 +383,9 @@ void load_into_dict(Cache::ldictcache & ldict, const char * data, size_t size) {
     protozero::pbf_reader message(data,size);
     while (message.next(1)) {
         protozero::pbf_reader item = message.get_message();
-        while (item.next(1)) {
+        if (item.next(1)) {
             uint64_t key_id = item.get_uint64();
             ldict.insert(trunc_hash(key_id));
-            break;
         }
     }
 }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -297,9 +297,9 @@ NAN_METHOD(Cache::list)
                 std::string ref = cacheGet(c, key);
 
                 protozero::pbf_reader message(ref);
-                while (message.next(1)) {
+                while (message.next(CACHE_MESSAGE)) {
                     protozero::pbf_reader item = message.get_message();
-                    while (item.next(1)) {
+                    while (item.next(CACHE_ITEM)) {
                         uint64_t key_id = item.get_uint64();
                         ids->Set(idx++, Nan::New<Number>(key_id)->ToString());
                     }

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -71,6 +71,9 @@ public:
     unsigned cachesize = 65536;
 };
 
+#define CACHE_MESSAGE 1
+#define CACHE_ITEM 1
+
 }
 
 #endif // __CARMEN_BINDING_HPP__


### PR DESCRIPTION
I noticed https://github.com/mapbox/protozero/commit/4e7e32ac5350ea6d3dcf78ff5e74faeee513a6e1 and this pull upgrades to that new API.

/cc @joto @flippmoke for gut check that my usage is optimal.

@apendleton @yhahn - I'm not seeing meaningful benchmarks for `cache.pack`, so let me know if I might be missing them. At this point I assume this pull will increase `cache.pack` performance but this is not verified.


