### PR TITLE
Handle potential exception in mergeQueue

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -184,10 +184,10 @@ NAN_METHOD(Cache::pack)
             // message.reserve(<length>)
             protozero::pbf_writer writer(message);
             for (auto const& item : itr->second) {
-                protozero::pbf_writer item_writer(writer,1);
-                item_writer.add_uint64(1,item.first);
                 std::size_t array_size = item.second.size();
                 if (array_size > 0) {
+                    protozero::pbf_writer item_writer(writer,1);
+                    item_writer.add_uint64(1,item.first);
                     // make copy of intarray so we can sort without
                     // modifying the original array
                     Cache::intarray varr = item.second;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -486,7 +486,7 @@ NAN_METHOD(Cache::merge)
     std::string method = *String::Utf8Value(info[2]->ToString());
 
     if (obj1->IsNull() || obj1->IsUndefined() || !node::Buffer::HasInstance(obj1)) return Nan::ThrowTypeError("argument 1 must be a Buffer");
-    if (obj2->IsNull() || obj2->IsUndefined() || !node::Buffer::HasInstance(obj2)) return Nan::ThrowTypeError("argument 1 must be a Buffer");
+    if (obj2->IsNull() || obj2->IsUndefined() || !node::Buffer::HasInstance(obj2)) return Nan::ThrowTypeError("argument 2 must be a Buffer");
 
     MergeBaton *baton = new MergeBaton();
     baton->pbf1 = std::string(node::Buffer::Data(obj1),node::Buffer::Length(obj1));

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -47,8 +47,7 @@ tape('#pack', function(assert) {
     // set should replace data
     cache._set('term', 0, 5, [0,1,2,4]);
     assert.deepEqual(cache.pack('term', 0).length, 10);
-    cache._set('term', 0, 5, []);
-    assert.deepEqual(cache.pack('term', 0).length, 4);
+    assert.throws(cache._set.bind(null, 'term', 0, 5, []), 'can\'t set empty term');
 
     // fake data
     var array = [];

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -56,6 +56,9 @@ tape('#merge invalid pbf throws JS error', function(assert) {
     var cacheA = new Cache('a');
     cacheA.merge(new Buffer("phony protobuf"), new Buffer("phony protobuf"), 'freq', function(err, merged) {
         assert.ok(err);
+        if (err) {
+            assert.ok(err.message.indexOf("unknown pbf field type exception") > -1);            
+        }
         assert.end();
     })
 });

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -54,13 +54,9 @@ tape('#merge freq', function(assert) {
 
 tape('#merge invalid pbf throws JS error', function(assert) {
     var cacheA = new Cache('a');
-    cacheA.merge(new Buffer("phony protobuf"), new Buffer("phony protobuf"), 'freq', function(err, merged) {
-        assert.ok(err);
-        if (err) {
-            assert.ok(err.message.indexOf("unknown pbf field type exception") > -1);            
-        }
-        assert.end();
-    })
+    var bound = cacheA.merge.bind(cacheA.merge, new Buffer("phony protobuf"), new Buffer("phony protobuf"), 'freq', function() {});
+    assert.throws(bound);
+    assert.end();
 });
 
 function numSort(a, b) { return a - b; }

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -52,4 +52,12 @@ tape('#merge freq', function(assert) {
     })
 });
 
+tape('#merge invalid pbf throws JS error', function(assert) {
+    var cacheA = new Cache('a');
+    cacheA.merge(new Buffer("phony protobuf"), new Buffer("phony protobuf"), 'freq', function(err, merged) {
+        assert.ok(err);
+        assert.end();
+    })
+});
+
 function numSort(a, b) { return a - b; }

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -54,9 +54,13 @@ tape('#merge freq', function(assert) {
 
 tape('#merge invalid pbf throws JS error', function(assert) {
     var cacheA = new Cache('a');
-    var bound = cacheA.merge.bind(cacheA.merge, new Buffer("phony protobuf"), new Buffer("phony protobuf"), 'freq', function() {});
-    assert.throws(bound);
-    assert.end();
+    cacheA.merge(new Buffer("phony protobuf"), new Buffer("phony protobuf"), 'freq', function(err, merged) {
+        assert.ok(err);
+        if (err) {
+            assert.ok(err.message.indexOf("unknown pbf field type exception") > -1);
+        }
+        assert.end();
+    })
 });
 
 function numSort(a, b) { return a - b; }


### PR DESCRIPTION
In all cases where C++ exceptions are possible we should use `try/catch` to ensure the C++ exception is sent back to JS land as a JS Error. C++ functions in the threadpool should use try/catch and then set a property of the baton to pass the error back to the main thread.

Followups needed:

  - coalesceSingle and coalesceMulti are also missing try/catch

/cc @sbma44 @yhahn @mapsam 