### PR TITLE
Performance: gridcache limit on coalesce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.14.0-top40-hits-dev1",
+  "version": "0.14.0-top40-hits-dev2",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.13.2",
+  "version": "0.14.0-top40-hits-dev1",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1062,7 +1062,7 @@ void coalesceSingle(uv_work_t* req) {
 
         // sort grids by distance to proximity point
         Cache::intarray grids = (proximity || bbox) ?
-            __get(subq.cache, type, shardId, subq.phrase) :
+            __getTruncated(subq.cache, type, shardId, subq.phrase, 500000) :
             __getTruncated(subq.cache, type, shardId, subq.phrase, 40);
 
         unsigned long m = grids.size();
@@ -1201,7 +1201,7 @@ void coalesceMulti(uv_work_t* req) {
 
             std::string shardId = shard(4, subq.phrase);
 
-            Cache::intarray grids = __get(subq.cache, type, shardId, subq.phrase);
+            Cache::intarray grids = __getTruncated(subq.cache, type, shardId, subq.phrase, 500000);
 
             unsigned short z = subq.zoom;
             auto const& zCache = zoomCache[z];

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1063,7 +1063,7 @@ void coalesceSingle(uv_work_t* req) {
         // sort grids by distance to proximity point
         Cache::intarray grids = (proximity || bbox) ?
             __getTruncated(subq.cache, type, shardId, subq.phrase, 500000) :
-            __getTruncated(subq.cache, type, shardId, subq.phrase, 40);
+            __getTruncated(subq.cache, type, shardId, subq.phrase, 100000);
 
         unsigned long m = grids.size();
         double relevMax = 0;


### PR DESCRIPTION
Limits individual gridcache gets to

- 500000 entries and 
- 100000 on coalescesingle without proximity/bbox

This optimization prevents extremely large gridcache shards (usually those for early degens, e.g. `a`) from having an outsized impact on performance. Since gridcache shards are presorted when stored this optimization largely excludes low scoring, low relevance features from consideration during coalesce.

These covers were definitely thrown out anyway by the final step of coalesce making this change have functionally equivalent handling of the spatialmatch process.

**Note:** These thresholds were tested with real data but are definitely heuristics. Example theoretical problem case: an example of gridcache shard that would push the boundaries of the 100k limit, for example, would be 11 textually matching features with 10k covers each (e.g. 11 Siberias). It's possible that one of the 11 features would be excluded.

cc @mapbox/geocoding-gang 