### PR TITLE
Rocksdb via mason

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,12 @@ env:
    - secure: lmfuNtK0/ubV4ZZobgfeKY6DzG41ZciS4a00yCe29jHLxAg+EEmB/qpsW5d1//cC94OKsAySW08xp2uX5wBVvtryaaoiwU7fdKF9DOxHRHieGw/3+m8NNjELkd5hKMKiqDj7l4QPMchzBQR2PQkoG0UMCGUFe+RmzZ2/iCdGHXU=
 
 before_install:
+ # TODO: after https://github.com/mapbox/mason/pull/305 merges point at official mason release
+ - git clone --branch rocksdb-4.13 --single-branch https://github.com/mapbox/mason.git
+ - ./mason/mason install bzip2 1.0.6
+ - ./mason/mason link bzip2 1.0.6
+ - ./mason/mason install rocksdb 4.13
+ - ./mason/mason link rocksdb 4.13
  - export COVERAGE=${COVERAGE:-false}
  - mkdir -p $(pwd)/.local
  - if [[ $(uname -s) == 'Linux' ]]; then

--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@
 carmen-cache
 ------------
 Protobuf-based cache. Written originally for use in [carmen](https://github.com/mapbox/carmen) geocoder.
+
+### Installing from source
+
+First install mason and then (from inside the carmen-cache) directory, install rocksdb:
+
+```
+mason install bzip2 1.0.6
+mason link bzip2 1.0.6
+mason install rocksdb 4.13
+mason link rocksdb 4.13
+```
+
+Then you can build carmen-cache from source like:
+
+```
+npm install --build-from-source
+```

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,9 +12,11 @@
           '<(SHARED_INTERMEDIATE_DIR)/',
           "<!(node -p -e \"require('path').dirname(require.resolve('nan'))\")",
           './node_modules/protozero/include/',
+          './mason_packages/.link/include/'
       ],
       "libraries": [
-        '-lrocksdb'
+        '<(module_root_dir)/mason_packages/.link/lib/libbz2.a',
+        '<(module_root_dir)/mason_packages/.link/lib/librocksdb.a'
       ],
       'ldflags': [
         '-Wl,-z,now',

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,12 +16,18 @@
       "libraries": [
         '-lrocksdb'
       ],
+      'ldflags': [
+        '-Wl,-z,now',
+      ],
       'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
       'cflags_cc' : [
           '-std=c++11',
           '-Wconversion'
       ],
       'xcode_settings': {
+        'OTHER_LDFLAGS':[
+          '-Wl,-bind_at_load'
+        ],
         'OTHER_CPLUSPLUSFLAGS':[
            '-Wshadow',
            '-Wconversion'

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,8 +15,8 @@
           './mason_packages/.link/include/'
       ],
       "libraries": [
-        '<(module_root_dir)/mason_packages/.link/lib/libbz2.a',
-        '<(module_root_dir)/mason_packages/.link/lib/librocksdb.a'
+        '<(module_root_dir)/mason_packages/.link/lib/librocksdb.a',
+        '<(module_root_dir)/mason_packages/.link/lib/libbz2.a'
       ],
       'ldflags': [
         '-Wl,-z,now',


### PR DESCRIPTION
This PR moves to depending on rocksdb via mason. This requires one-time manual install of mason and rocksdb locally. See `.travis.yml`/Readme diff for how to do it.