### PR TITLE
Modernize build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,22 +3,27 @@
   'targets': [
     {
       'target_name': '<(module_name)',
+      'product_dir': '<(module_path)',
       'sources': [
         "./src/binding.cpp"
       ],
       "include_dirs" : [
           'src/',
-          'deps/',
-          '<(SHARED_INTERMEDIATE_DIR)/',
-          "<!(node -p -e \"require('path').dirname(require.resolve('nan'))\")",
-          './node_modules/protozero/include/',
+          '<!(node -e \'require("nan")\')',
+          '<!(node -e \'require("protozero")\')',
       ],
       'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
       'cflags_cc' : [
           '-std=c++11',
           '-Wconversion'
       ],
+      'ldflags': [
+        '-Wl,-z,now',
+      ],
       'xcode_settings': {
+        'OTHER_LDFLAGS':[
+          '-Wl,-bind_at_load'
+        ],
         'OTHER_CPLUSPLUSFLAGS':[
            '-Wshadow',
            '-Wconversion'
@@ -30,17 +35,6 @@
         'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
       }
-    },
-    {
-      'target_name': 'action_after_build',
-      'type': 'none',
-      'dependencies': [ '<(module_name)' ],
-      'copies': [
-          {
-            'files': [ '<(PRODUCT_DIR)/<(module_name).node' ],
-            'destination': '<(module_path)'
-          }
-      ]
     }
   ]
 }

--- a/common.gypi
+++ b/common.gypi
@@ -1,32 +1,45 @@
 {
   'target_defaults': {
-      'default_configuration': 'Release',
-      'configurations': {
-          'Debug': {
-              'defines!': [ 'NDEBUG' ],
-              'cflags_cc!': ['-O3', '-Os', '-DNDEBUG'],
-              'xcode_settings': {
-                'OTHER_CPLUSPLUSFLAGS!':['-O3', '-Os', '-DDEBUG'],
-                'GCC_OPTIMIZATION_LEVEL': '0',
-                'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES'
-              }
-          },
-          'Release': {
-              'defines': [
-                'NDEBUG'
-              ],
-              'xcode_settings': {
-                'OTHER_CPLUSPLUSFLAGS!':['-Os', '-O2'],
-                'OTHER_CPLUSPLUSFLAGS':[],
-                'GCC_OPTIMIZATION_LEVEL': '3',
-                'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
-                'DEAD_CODE_STRIPPING':'YES',
-                'GCC_INLINES_ARE_PRIVATE_EXTERN':'YES',
-              },
-              'ldflags': [
-                    '-Wl,-s'
-              ]
-          }
+    'default_configuration': 'Release',
+    'cflags_cc' : [
+      '-std=c++11',
+    ],
+    'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
+    'configurations': {
+      'Debug': {
+        'defines!': [
+          'NDEBUG'
+        ],
+        'cflags_cc!': [
+          '-O3',
+          '-Os',
+          '-DNDEBUG'
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS!': [
+            '-O3',
+            '-Os',
+            '-DDEBUG'
+          ],
+          'GCC_OPTIMIZATION_LEVEL': '0',
+          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES'
+        }
+      },
+      'Release': {
+        'defines': [
+          'NDEBUG'
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS!': [
+            '-Os',
+            '-O2'
+          ],
+          'GCC_OPTIMIZATION_LEVEL': '3',
+          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
+          'DEAD_CODE_STRIPPING': 'YES',
+          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES'
+        }
       }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "url": "git://github.com/mapbox/carmen-cache.git"
   },
   "dependencies": {
-    "nan": "~2.2.0",
-    "node-pre-gyp": "~0.6.28",
-    "protozero": "~1.3.0"
+    "nan": "~2.4.0",
+    "node-pre-gyp": "~0.6.32",
+    "protozero": "~1.4.5"
   },
   "devDependencies": {
     "tape": "3.0.x"


### PR DESCRIPTION
This PR modernizes the build by applying learning and templates from https://github.com/mapbox/node-cpp-skel/ (:tada: thanks @GretaCB and @mapsam) and upgrading deps. Here is a rundown of the changes:

 - Now using `product_dir` to copy the binary into the proper "versioned" spot for node-pre-gyp to be able to package portabily (reduces extra target)
 - Removes the `deps/` and `<(SHARED_INTERMEDIATE_DIR)/` include directories - these were only needed back when we vendored libprotobuf (before moving to `protozero`)
 - Upgrades `protozero` and starts dynamically finding its location using https://github.com/mapbox/protozero/pull/59. This avoids possible breakage downstream if another module depended on protozero and npm deduped it.
 - Adds linker flags (`-Wl,-z,now` on linux, `-Wl,-bind_at_load` on osx) to ensure that missing symbols create an error at startup. Without these flags you could have lurking problems that would only manifest in production or start happening when new tests are added that hit new C++ code paths.
 - Pulls over the `common.gypi` from node-cpp-skel which handles more edge cases (like node > v4 setting a c++11 flag that conflicts with c++14)