### PR TITLE
Move mason install from the travis yml to a pre-build gyp action

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 /build
 /test
 /lib/carmen.node
+/mason
+/mason_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,6 @@ env:
    - secure: lmfuNtK0/ubV4ZZobgfeKY6DzG41ZciS4a00yCe29jHLxAg+EEmB/qpsW5d1//cC94OKsAySW08xp2uX5wBVvtryaaoiwU7fdKF9DOxHRHieGw/3+m8NNjELkd5hKMKiqDj7l4QPMchzBQR2PQkoG0UMCGUFe+RmzZ2/iCdGHXU=
 
 before_install:
- # TODO: after https://github.com/mapbox/mason/pull/305 merges point at official mason release
- - git clone --branch rocksdb-4.13 --single-branch https://github.com/mapbox/mason.git
- - ./mason/mason install bzip2 1.0.6
- - ./mason/mason link bzip2 1.0.6
- - ./mason/mason install rocksdb 4.13
- - ./mason/mason link rocksdb 4.13
  - export COVERAGE=${COVERAGE:-false}
  - mkdir -p $(pwd)/.local
  - if [[ $(uname -s) == 'Linux' ]]; then

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,21 @@
   'includes': [ 'common.gypi' ],
   'targets': [
     {
+      'target_name': 'action_before_build',
+      'type': 'none',
+      'hard_dependency': 1,
+      'actions': [
+        {
+          'action_name': 'install_mason',
+          'inputs': ['./install_mason.sh'],
+          'outputs': ['./mason_packages'],
+          'action': ['./install_mason.sh']
+        }
+      ]
+    },
+    {
       'target_name': '<(module_name)',
+      'dependencies': [ 'action_before_build' ],
       'product_dir': '<(module_path)',
       'sources': [
         "./src/binding.cpp"

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -d ./mason ]; then
+    # TODO: after https://github.com/mapbox/mason/pull/305 merges point at official mason release
+    git clone --branch rocksdb-4.13 --single-branch https://github.com/mapbox/mason.git
+    ./mason/mason install bzip2 1.0.6
+    ./mason/mason link bzip2 1.0.6
+    ./mason/mason install rocksdb 4.13
+    ./mason/mason link rocksdb 4.13
+fi


### PR DESCRIPTION
The [rocksdb via mason](https://github.com/mapbox/carmen-cache/pull/62) PR moved to mason for installing rocksdb, and installed mason and rocksdb in the `.travis.yml` file for running on CI, but otherwise required devs to manually install them. We often work on interacting carmen and carmen-cache changes with a carmen branch that points at a `/tarball` Github URL of a carmen-cache branch for which a `node-pre-gyp` prebuilt binary does not exist, and this was failing on the rocksdb branch because mason was not getting installed in that case. This PR moves the mason install into a node-gyp pre-build action so that it always gets run, regardless of whether it's on travis or as part of an npm install.

@springmeyer curious if you think this is a bad idea, and if so, if there are better ways to do this.