### PR TITLE
Use mason@master

### DIFF
--- a/install_mason.sh
+++ b/install_mason.sh
@@ -2,7 +2,7 @@
 
 if [ ! -d ./mason ]; then
     # TODO: after https://github.com/mapbox/mason/pull/305 merges point at official mason release
-    git clone --branch rocksdb-4.13 --single-branch https://github.com/mapbox/mason.git
+    git clone --branch master --single-branch https://github.com/mapbox/mason.git
     ./mason/mason install bzip2 1.0.6
     ./mason/mason link bzip2 1.0.6
     ./mason/mason install rocksdb 4.13


### PR DESCRIPTION
I've merged the rocksdb package for mason (https://github.com/mapbox/mason/pull/305). Let's merge this and afterward it will be safe to delete the `rocksdb-4.13` branch of mason.

/cc @apendleton 