### PR TITLE
Shrink cachesize to 2048

### DIFF
--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -61,7 +61,7 @@ public:
     memcache cache_;
     message_cache msg_;
     message_list msglist_;
-    unsigned cachesize = 131072;
+    unsigned cachesize = 2048;
 };
 
 #define CACHE_MESSAGE 1


### PR DESCRIPTION
Massively shrink our grid cache size -- our previous implementations were cycling carmen-caches but now that we're persisting them over long periods of time the cap on memory growth is very necessary.

cc @mapbox/geocoding-gang 