### PR TITLE
Optimize merge code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: generic
 
 sudo: false
 
@@ -6,42 +6,39 @@ addons:
   apt:
     sources:
      - ubuntu-toolchain-r-test
-     - llvm-toolchain-precise-3.5
     packages:
-     - clang-3.5
+     - libstdc++-4.9-dev
 
 matrix:
   include:
      # Coverage
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10.38" COVERAGE=true
+       env: NODE_VERSION="4" COVERAGE=true
+       osx_image: xcode8.2
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.12.2" # node abi 14
+       env: NODE_VERSION="0.10" # node abi 11
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="4" # node abi 46
      - os: linux
        compiler: clang
-       env: NODE_VERSION="4.2.4" # node abi 46
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="5.4.1" # node abi 47
+       env: NODE_VERSION="6" # node abi 48
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.12.2" # node abi 14
+       env: NODE_VERSION="0.10" # node abi 11
+       osx_image: xcode8.2
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="4" # node abi 46
+       osx_image: xcode8.2
      - os: osx
        compiler: clang
-       env: NODE_VERSION="4.2.4" # node abi 46
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="5.4.1" # node abi 47
+       env: NODE_VERSION="6" # node abi 48
+       osx_image: xcode8.2
 
 env:
   global:
@@ -50,11 +47,14 @@ env:
    - secure: lmfuNtK0/ubV4ZZobgfeKY6DzG41ZciS4a00yCe29jHLxAg+EEmB/qpsW5d1//cC94OKsAySW08xp2uX5wBVvtryaaoiwU7fdKF9DOxHRHieGw/3+m8NNjELkd5hKMKiqDj7l4QPMchzBQR2PQkoG0UMCGUFe+RmzZ2/iCdGHXU=
 
 before_install:
+ # install clang++ via mason
+ - mkdir /tmp/mason && curl -sSfL https://github.com/mapbox/mason/archive/v0.5.0.tar.gz | tar --gunzip --extract --strip-components=1 --directory=/tmp/mason
+ - /tmp/mason/mason install clang++ 3.9.1
+ - export PATH=$(/tmp/mason/mason prefix clang++ 3.9.1)/bin:${PATH}
+ - export CXX=clang++-3.9
  - export COVERAGE=${COVERAGE:-false}
  - mkdir -p $(pwd)/.local
  - if [[ $(uname -s) == 'Linux' ]]; then
-     export CXX="clang++-3.5";
-     export CC="clang-3.5";
      export PYTHONPATH=$(pwd)/.local/lib/python2.7/site-packages;
    else
      export PYTHONPATH=$(pwd)/.local/lib/python/site-packages;

--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,6 @@
       ],
       'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
       'cflags_cc' : [
-          '-std=c++11',
           '-Wconversion'
       ],
       'ldflags': [
@@ -32,7 +31,7 @@
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'MACOSX_DEPLOYMENT_TARGET':'10.8',
         'CLANG_CXX_LIBRARY': 'libc++',
-        'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+        'CLANG_CXX_LANGUAGE_STANDARD':'c++14',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
       }
     }

--- a/common.gypi
+++ b/common.gypi
@@ -2,7 +2,7 @@
   'target_defaults': {
     'default_configuration': 'Release',
     'cflags_cc' : [
-      '-std=c++11',
+      '-std=c++14',
     ],
     'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
     'configurations': {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <limits>
 #include <algorithm>
+#include <memory>
 
 #include <protozero/pbf_writer.hpp>
 #include <protozero/pbf_reader.hpp>
@@ -280,31 +281,56 @@ NAN_METHOD(Cache::pack)
 
 struct MergeBaton : carmen::noncopyable {
     uv_work_t request;
-    std::string pbf1;
-    std::string pbf2;
-    std::string pbf3;
+    std::unique_ptr<std::string> pbf3;
+    const char * pbf1_data;
+    const char * pbf2_data;
     std::string method;
     std::string error;
     Nan::Persistent<v8::Function> callback;
+    Nan::Persistent<v8::Object> buffer1;
+    Nan::Persistent<v8::Object> buffer2;
+    std::size_t pbf1_size;
+    std::size_t pbf2_size;
+    MergeBaton(Local<Object> obj1,
+               Local<Object> obj2,
+               Local<Value> cb,
+               std::string const& meth)
+      : pbf1_data(node::Buffer::Data(obj1)),
+        pbf1_size(node::Buffer::Length(obj1)),
+        pbf2_data(node::Buffer::Data(obj2)),
+        pbf2_size(node::Buffer::Length(obj2)),
+        pbf3(std::make_unique<std::string>()),
+        method(meth)
+      {
+        this->request.data = this;
+        callback.Reset(cb.As<Function>());
+        buffer1.Reset(obj1);
+        buffer2.Reset(obj2);
+      }
+    ~MergeBaton() {
+        callback.Reset();
+        buffer1.Reset();
+        buffer2.Reset();        
+    }
+
 };
 
 void mergeQueue(uv_work_t* req) {
     MergeBaton *baton = static_cast<MergeBaton *>(req->data);
-    std::string const& pbf1 = baton->pbf1;
-    std::string const& pbf2 = baton->pbf2;
+
     std::string const& method = baton->method;
 
     // Ids that have been seen
     std::map<uint64_t,bool> ids1;
     std::map<uint64_t,bool> ids2;
 
-    std::string merged;
+    std::string & merged = *baton->pbf3.get();
     try {
 
         protozero::pbf_writer writer(merged);
 
         // Store ids from 1
-        protozero::pbf_reader pre1(pbf1);
+        protozero::pbf_reader pre1(baton->pbf1_data,baton->pbf1_size);
         while (pre1.next(CACHE_MESSAGE)) {
             protozero::pbf_reader item = pre1.get_message();
             while (item.next(CACHE_ITEM)) {
@@ -313,7 +339,7 @@ void mergeQueue(uv_work_t* req) {
         }
 
         // Store ids from 2
-        protozero::pbf_reader pre2(pbf2);
+        protozero::pbf_reader pre2(baton->pbf2_data,baton->pbf2_size);
         while (pre2.next(CACHE_MESSAGE)) {
             protozero::pbf_reader item = pre2.get_message();
             while (item.next(CACHE_ITEM)) {
@@ -322,7 +348,7 @@ void mergeQueue(uv_work_t* req) {
         }
 
         // No delta writes from message1
-        protozero::pbf_reader message1(pbf1);
+        protozero::pbf_reader message1(baton->pbf1_data,baton->pbf1_size);
         while (message1.next(CACHE_MESSAGE)) {
             protozero::pbf_writer item_writer(writer,1);
             protozero::pbf_reader item = message1.get_message();
@@ -343,7 +369,7 @@ void mergeQueue(uv_work_t* req) {
         }
 
         // No delta writes from message2
-        protozero::pbf_reader message2(pbf2);
+        protozero::pbf_reader message2(baton->pbf2_data,baton->pbf2_size);
         while (message2.next(CACHE_MESSAGE)) {
             protozero::pbf_writer item_writer(writer,1);
             protozero::pbf_reader item = message2.get_message();
@@ -364,7 +390,7 @@ void mergeQueue(uv_work_t* req) {
         }
 
         // Delta writes for ids in both message1 and message2
-        protozero::pbf_reader overlap1(pbf1);
+        protozero::pbf_reader overlap1(baton->pbf1_data,baton->pbf1_size);
         while (overlap1.next(CACHE_MESSAGE)) {
             protozero::pbf_writer item_writer(writer,1);
             protozero::pbf_reader item = overlap1.get_message();
@@ -396,7 +422,7 @@ void mergeQueue(uv_work_t* req) {
                 }
 
                 // Check pbf2 for this id and merge its items if found
-                protozero::pbf_reader overlap2(pbf2);
+                protozero::pbf_reader overlap2(baton->pbf2_data,baton->pbf2_size);
                 while (overlap2.next(CACHE_MESSAGE)) {
                     protozero::pbf_reader item2 = overlap2.get_message();
                     while (item2.next(CACHE_ITEM)) {
@@ -440,8 +466,6 @@ void mergeQueue(uv_work_t* req) {
                 }
             }
         }
-
-        baton->pbf3 = merged;
     } catch (std::exception const& ex) {
         baton->error = ex.what();
     }
@@ -454,12 +478,19 @@ void mergeAfter(uv_work_t* req) {
         v8::Local<v8::Value> argv[1] = { Nan::Error(baton->error.c_str()) };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(baton->callback), 1, argv);
     } else {
-        std::string const& merged = baton->pbf3;
-        Local<Object> buf = Nan::CopyBuffer((char*)merged.data(), merged.size()).ToLocalChecked();
-        Local<Value> argv[2] = { Nan::Null(), buf };
+        std::string & merged = *baton->pbf3.get();
+        baton->pbf3.release();
+        v8::Local<v8::Value> argv[2] = { Nan::Null(),
+                                         Nan::NewBuffer(const_cast<char *>(merged.data()),
+                                            merged.size(),
+                                            [](char *, void * hint) {
+                                                delete reinterpret_cast<std::string*>(hint);
+                                            },
+                                            baton->pbf3.get()
+                                         ).ToLocalChecked()
+                                       };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(baton->callback), 2, argv);
     }
-    baton->callback.Reset();
     delete baton;
 }
 
@@ -546,14 +577,8 @@ NAN_METHOD(Cache::merge)
     if (obj1->IsNull() || obj1->IsUndefined() || !node::Buffer::HasInstance(obj1)) return Nan::ThrowTypeError("argument 1 must be a Buffer");
     if (obj2->IsNull() || obj2->IsUndefined() || !node::Buffer::HasInstance(obj2)) return Nan::ThrowTypeError("argument 2 must be a Buffer");
 
-    MergeBaton *baton = new MergeBaton();
-    baton->pbf1 = std::string(node::Buffer::Data(obj1),node::Buffer::Length(obj1));
-    baton->pbf2 = std::string(node::Buffer::Data(obj2),node::Buffer::Length(obj2));
-    baton->method = method;
-    baton->callback.Reset(callback.As<Function>());
-    baton->request.data = baton;
+    MergeBaton *baton = new MergeBaton(obj1,obj2,callback,method);
     uv_queue_work(uv_default_loop(), &baton->request, mergeQueue, (uv_after_work_cb)mergeAfter);
-
     info.GetReturnValue().Set(Nan::Undefined());
     return;
 }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -306,6 +306,8 @@ struct MergeBaton : carmen::noncopyable {
         callback.Reset(cb.As<Function>());
         buffer1.Reset(obj1);
         buffer2.Reset(obj2);
+        // Reserve memory at least at pbf1_size. TODO: should we reserve more?
+        pbf3.get()->reserve(pbf1_size);
       }
     ~MergeBaton() {
         callback.Reset();

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -483,7 +483,7 @@ void mergeAfter(uv_work_t* req) {
         std::string & merged = *baton->pbf3.get();
         baton->pbf3.release();
         v8::Local<v8::Value> argv[2] = { Nan::Null(),
-                                         Nan::NewBuffer(const_cast<char *>(merged.data()),
+                                         Nan::NewBuffer(&merged[0],
                                             merged.size(),
                                             [](char *, void * hint) {
                                                 delete reinterpret_cast<std::string*>(hint);


### PR DESCRIPTION
This optimizes the async merge implementation by significantly reducing memory allocations.

Previously a `std::string` was allocated and copied once for each of the two pbf buffers passed in. Now these buffers are passed in a zero-copy way by taking a pointer to their memory and marking them as `Persistent` to ensure they are safe to use in the threadpool (So the memory from JS is used directly in the C++ threadpool).

Also previously the final merged pbf (aka `pbf3` in the code) was allocated and copied twice: once in the threadpool (`baton->pbf3 = merged;`) and another time in `Nan::CopyBuffer`. Now instead we allocate once and pass in a zero-copy way directly into `Nan::NewBuffer`. We use C++14 features (`make_unique`) and a `unique_ptr` to accomplish this handoff. Also the buffer is now pre-allocated by the size of the first pbf1 to avoid unnecessary re-allocations during the protozero append (this could be tuned further if we can better anticipate the final size).