### PR TITLE
Avoid possible invalid memory access in async coalesce

### DIFF
--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -58,6 +58,8 @@ public:
     static NAN_METHOD(unload);
     static NAN_METHOD(coalesce);
     explicit Cache();
+    void _ref() { Ref(); }
+    void _unref() { Unref(); }
     memcache cache_;
     message_cache msg_;
     message_list msglist_;


### PR DESCRIPTION
The `coalesce` function needs to reference count the cache objects passed in. This PR starts doing this. Without reference counting the node.js garbage collector is allowed to collect the `Cache` objects before the threadpool is done working with them. This would result in invalid memory access in the `coalesce` code and therefore undefined behavior.

/cc @yhahn 