### PR TITLE
Optimize loadSync (redux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: generic
 
 sudo: false
 
@@ -6,42 +6,39 @@ addons:
   apt:
     sources:
      - ubuntu-toolchain-r-test
-     - llvm-toolchain-precise-3.5
     packages:
-     - clang-3.5
+     - libstdc++-4.9-dev
 
 matrix:
   include:
      # Coverage
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10.38" COVERAGE=true
+       env: NODE_VERSION="4" COVERAGE=true
+       osx_image: xcode8.2
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.12.2" # node abi 14
+       env: NODE_VERSION="0.10" # node abi 11
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="4" # node abi 46
      - os: linux
        compiler: clang
-       env: NODE_VERSION="4.2.4" # node abi 46
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="5.4.1" # node abi 47
+       env: NODE_VERSION="6" # node abi 48
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.12.2" # node abi 14
+       env: NODE_VERSION="0.10" # node abi 11
+       osx_image: xcode8.2
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="4" # node abi 46
+       osx_image: xcode8.2
      - os: osx
        compiler: clang
-       env: NODE_VERSION="4.2.4" # node abi 46
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="5.4.1" # node abi 47
+       env: NODE_VERSION="6" # node abi 48
+       osx_image: xcode8.2
 
 env:
   global:
@@ -50,11 +47,14 @@ env:
    - secure: lmfuNtK0/ubV4ZZobgfeKY6DzG41ZciS4a00yCe29jHLxAg+EEmB/qpsW5d1//cC94OKsAySW08xp2uX5wBVvtryaaoiwU7fdKF9DOxHRHieGw/3+m8NNjELkd5hKMKiqDj7l4QPMchzBQR2PQkoG0UMCGUFe+RmzZ2/iCdGHXU=
 
 before_install:
+ # install clang++ via mason
+ - mkdir /tmp/mason && curl -sSfL https://github.com/mapbox/mason/archive/v0.5.0.tar.gz | tar --gunzip --extract --strip-components=1 --directory=/tmp/mason
+ - /tmp/mason/mason install clang++ 3.9.1
+ - export PATH=$(/tmp/mason/mason prefix clang++ 3.9.1)/bin:${PATH}
+ - export CXX=clang++-3.9
  - export COVERAGE=${COVERAGE:-false}
  - mkdir -p $(pwd)/.local
  - if [[ $(uname -s) == 'Linux' ]]; then
-     export CXX="clang++-3.5";
-     export CC="clang-3.5";
      export PYTHONPATH=$(pwd)/.local/lib/python2.7/site-packages;
    else
      export PYTHONPATH=$(pwd)/.local/lib/python/site-packages;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -68,14 +68,14 @@ inline bool cacheHas(Cache const* c, std::string const& key) {
     return mitr != messages.end();
 }
 
-inline void cacheInsert(Cache * c, std::string const& key, std::string const& message) {
-    Cache::message_list &list = c->msglist_;
-    Cache::message_cache &messages = c->msg_;
+inline void cacheInsert(Cache & c, std::string const& key, const char * data, std::size_t data_size) {
+    Cache::message_cache &messages = c.msg_;
     Cache::message_cache::iterator mitr = messages.find(key);
     if (mitr == messages.end()) {
-        list.emplace_front(std::make_pair(key, message));
+        Cache::message_list &list = c.msglist_;
+        list.emplace_front(key, std::string(data,data_size));
         messages.emplace(key, list.begin());
-        if (list.size() > c->cachesize) {
+        if (list.size() > c.cachesize) {
             messages.erase(list.back().first);
             list.pop_back();
         }
@@ -642,10 +642,17 @@ NAN_METHOD(Cache::_set)
     return;
 }
 
+/*
+
+Note: This function will not override data for keys already inserted into the cache
+
+*/
+
+
 NAN_METHOD(Cache::loadSync)
 {
     if (info.Length() < 2) {
-        return Nan::ThrowTypeError("expected at three info: 'buffer', 'type', and 'shard'");
+        return Nan::ThrowTypeError("expected at least three args: 'buffer', 'type', and 'shard'");
     }
     if (!info[0]->IsObject()) {
         return Nan::ThrowTypeError("first argument must be a Buffer");
@@ -667,19 +674,8 @@ NAN_METHOD(Cache::loadSync)
         std::string type = *String::Utf8Value(info[1]->ToString());
         std::string shard = *String::Utf8Value(info[2]->ToString());
         std::string key = type + "-" + shard;
-        Cache* c = node::ObjectWrap::Unwrap<Cache>(info.This());
-        Cache::memcache & mem = c->cache_;
-        Cache::memcache::iterator itr = mem.find(key);
-        if (itr != mem.end()) {
-            c->cache_.emplace(key,arraycache());
-        }
-        Cache::memcache::iterator itr2 = mem.find(key);
-        if (itr2 != mem.end()) {
-            mem.erase(itr2);
-        }
-        if (!cacheHas(c, key)) {
-            cacheInsert(c, key, std::string(node::Buffer::Data(obj),node::Buffer::Length(obj)));
-        }
+        Cache & c = *node::ObjectWrap::Unwrap<Cache>(info.This());
+        cacheInsert(c, key, node::Buffer::Data(obj), node::Buffer::Length(obj));
     } catch (std::exception const& ex) {
         return Nan::ThrowTypeError(ex.what());
     }


### PR DESCRIPTION
From https://github.com/mapbox/carmen-cache/pull/70:

------

During a general code review I noticed a few small optimizations that could be made to `loadSync`:

  - Avoiding trying to remove keys before inserting. This is only needed if we need to overwrite existing keys already in the cache but I see no sign in the tests that this is needed.
  - Removing `std::make_pair` call from `list.emplace_front`. This will be called internally when arguments are forwarded and then constructed in-place.
  - Passing the message string to `list.emplace_front` so that it is constructed once (in place rather than being allocated and then copied into place).

Running the `test/cache.bench.test.js` locally I get:

### master

```
# bench loadSync
ok 3 loadSync x256 took 229ms
```

### this branch

```
# bench loadSync
ok 3 loadSync x256 took 171ms
```
