### PR TITLE
Move safely + coalesce optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.16.3-move-safely-dev1",
+  "version": "0.16.3-move-safely-dev2",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen-cache",
   "description": "C++ protobuf cache used by carmen",
-  "version": "0.16.2",
+  "version": "0.16.3-move-safely-dev1",
   "url": "http://github.com/mapbox/carmen-cache",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1051,29 +1051,28 @@ double scoredist(unsigned zoom, double distance, double score) {
 }
 
 void coalesceFinalize(CoalesceBaton* baton, std::vector<Context> && contexts) {
-    if (contexts.size() > 0) {
+    if (!contexts.empty()) {
         // Coalesce stack, generate relevs.
         double relevMax = contexts[0].relev;
-        unsigned short total = 0;
+        std::size_t total = 0;
         std::map<uint64_t,bool> sets;
         std::map<uint64_t,bool>::iterator sit;
 
-        for (unsigned short i = 0; i < contexts.size(); i++) {
+        for (auto && context : contexts) {
             // Maximum allowance of coalesced features: 40.
             if (total >= 40) break;
 
-            Context const& feature = contexts[i];
-
             // Since `coalesced` is sorted by relev desc at first
             // threshold miss we can break the loop.
-            if (relevMax - feature.relev >= 0.25) break;
+            if (relevMax - context.relev >= 0.25) break;
 
             // Only collect each feature once.
-            sit = sets.find(feature.coverList[0].tmpid);
+            uint32_t id = context.coverList[0].tmpid;
+            sit = sets.find(id);
             if (sit != sets.end()) continue;
 
-            sets.emplace(feature.coverList[0].tmpid, true);
-            baton->features.emplace_back(std::move(contexts[i]));
+            sets.emplace(id, true);
+            baton->features.emplace_back(std::move(context));
             total++;
         }
     }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1275,6 +1275,7 @@ void coalesceMulti(uv_work_t* req) {
 
             Cache::intarray grids = __getTruncated(subq.cache, type, shardId, subq.phrase, 500000);
 
+            bool first = i == 0;
             bool last = i == (stack.size() - 1);
             unsigned short z = subq.zoom;
             auto const& zCache = zoomCache[i];
@@ -1357,7 +1358,7 @@ void coalesceMulti(uv_work_t* req) {
                         context_relev -= 0.01;
                     }
                     contexts.emplace_back(std::move(covers),context_mask,context_relev);
-                } else {
+                } else if (first || covers.size() > 1) {
                     cit = coalesced.find(zxy);
                     if (cit == coalesced.end()) {
                         std::vector<Context> local_contexts;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -861,6 +861,7 @@ struct Context {
     unsigned mask;
     double relev;
 
+    Context(Context const& c) = default;
     Context(Cover && cov,
             unsigned mask,
             double relev)
@@ -1185,10 +1186,10 @@ void coalesceSingle(uv_work_t* req) {
             lastid = cover.id;
             added++;
 
-            double relev = covers.relev;
+            double relev = cover.relev;
             // TODO correct default mask value?
             unsigned mask = 0;
-            contexts.emplace_back(std::move(covers),mask,relev);
+            contexts.emplace_back(std::move(cover),mask,relev);
         }
 
         coalesceFinalize(baton, std::move(contexts));
@@ -1371,9 +1372,10 @@ void coalesceMulti(uv_work_t* req) {
             i++;
         }
 
-        for (auto &matched : coalesced) {
-            for (auto &context : matched.second) {
-                contexts.emplace_back(std::move(context));
+        // append coalesced to contexts by moving memory
+        for (auto const& matched : coalesced) {
+            for (auto const&context : matched.second) {
+                contexts.emplace_back(context);
             }
         }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1170,7 +1170,7 @@ void coalesceSingle(uv_work_t* req) {
         std::sort(covers.begin(), covers.end(), coverSortByRelev);
 
         uint32_t lastid = 0;
-        unsigned short added = 0;
+        std::size_t added = 0;
         std::vector<Context> contexts;
         m = covers.size();
         contexts.reserve(m);
@@ -1200,7 +1200,7 @@ void coalesceMulti(uv_work_t* req) {
     try {
         std::vector<PhrasematchSubq> &stack = baton->stack;
         std::sort(stack.begin(), stack.end(), subqSortByZoom);
-        unsigned short stackSize = stack.size();
+        std::size_t stackSize = stack.size();
 
         // Cache zoom levels to iterate over as coalesce occurs.
         std::vector<Cache::intarray> zoomCache;
@@ -1265,7 +1265,7 @@ void coalesceMulti(uv_work_t* req) {
         }
 
         std::vector<Context> contexts;
-        unsigned short i = 0;
+        std::size_t i = 0;
         for (auto const& subq : stack) {
             std::string shardId = shard(4, subq.phrase);
 
@@ -1419,7 +1419,7 @@ void coalesceAfter(uv_work_t* req) {
         std::vector<Context> const& features = baton->features;
 
         Local<Array> jsFeatures = Nan::New<Array>(static_cast<int>(features.size()));
-        for (unsigned short i = 0; i < features.size(); i++) {
+        for (std::size_t i = 0; i < features.size(); i++) {
             jsFeatures->Set(i, contextToArray(features[i]));
         }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1373,9 +1373,9 @@ void coalesceMulti(uv_work_t* req) {
         }
 
         // append coalesced to contexts by moving memory
-        for (auto const& matched : coalesced) {
-            for (auto const&context : matched.second) {
-                contexts.emplace_back(context);
+        for (auto && matched : coalesced) {
+            for (auto &&context : matched.second) {
+                contexts.emplace_back(std::move(context));
             }
         }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1309,7 +1309,7 @@ void coalesceMulti(uv_work_t* req) {
                 // subqueries that are being coalesced.
                 std::vector<Cover> covers;
                 covers.reserve(stackSize);
-                covers.push_back(std::move(cover));
+                covers.push_back(cover);
                 unsigned context_mask = cover.mask;
                 double context_relev = cover.relev;
 


### PR DESCRIPTION
- @springmeyer's fixes for `std::move()` safety in coalesce()
- @yhahn's _One Small Trick To Optimize coalesce()_

Ready for release once IRL integration tests pass.