### PR TITLE
Expand 'mask' bitmask space from unsigned short to uint32_t (16=>32 bits)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "protozero": "~1.4.5"
   },
   "devDependencies": {
-    "tape": "3.0.x"
+    "tape": "^4.6.3"
   },
   "main": "./index.js",
   "scripts": {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -840,7 +840,7 @@ struct PhrasematchSubq {
     uint64_t phrase;
     unsigned short idx;
     unsigned short zoom;
-    unsigned short mask;
+    uint32_t mask;
 };
 
 struct Cover {
@@ -851,19 +851,19 @@ struct Cover {
     unsigned short y;
     unsigned short score;
     unsigned short idx;
-    unsigned short mask;
+    uint32_t mask;
     unsigned distance;
     double scoredist;
 };
 
 struct Context {
     std::vector<Cover> coverList;
-    unsigned mask;
+    uint32_t mask;
     double relev;
 
     Context(Context const& c) = default;
     Context(Cover && cov,
-            unsigned mask,
+            uint32_t mask,
             double relev)
      : coverList(),
        mask(mask),
@@ -877,7 +877,7 @@ struct Context {
         return *this;
     }
     Context(std::vector<Cover> && cl,
-            unsigned mask,
+            uint32_t mask,
             double relev)
      : coverList(std::move(cl)),
        mask(mask),
@@ -1187,8 +1187,7 @@ void coalesceSingle(uv_work_t* req) {
             added++;
 
             double relev = cover.relev;
-            // TODO correct default mask value?
-            unsigned mask = 0;
+            uint32_t mask = 0;
             contexts.emplace_back(std::move(cover),mask,relev);
         }
 
@@ -1312,7 +1311,7 @@ void coalesceMulti(uv_work_t* req) {
                 std::vector<Cover> covers;
                 covers.reserve(stackSize);
                 covers.push_back(cover);
-                unsigned context_mask = cover.mask;
+                uint32_t context_mask = cover.mask;
                 double context_relev = cover.relev;
 
                 for (unsigned a = 0; a < zCacheSize; a++) {
@@ -1323,7 +1322,7 @@ void coalesceMulti(uv_work_t* req) {
                         static_cast<uint64_t>(std::floor(cover.y/s));
                     pit = coalesced.find(pxy);
                     if (pit != coalesced.end()) {
-                        unsigned lastMask = 0;
+                        uint32_t lastMask = 0;
                         double lastRelev = 0.0;
                         for (auto const& parents : pit->second) {
                             for (auto const& parent : parents.coverList) {
@@ -1475,7 +1474,7 @@ NAN_METHOD(Cache::coalesce) {
 
             subq.weight = jsStack->Get(Nan::New("weight").ToLocalChecked())->NumberValue();
             subq.phrase = jsStack->Get(Nan::New("phrase").ToLocalChecked())->IntegerValue();
-            subq.mask = static_cast<unsigned short>(jsStack->Get(Nan::New("mask").ToLocalChecked())->IntegerValue());
+            subq.mask = static_cast<std::uint32_t>(jsStack->Get(Nan::New("mask").ToLocalChecked())->IntegerValue());
 
             // JS cache reference => cpp
             Local<Object> cache = Local<Object>::Cast(jsStack->Get(Nan::New("cache").ToLocalChecked()));

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -698,7 +698,7 @@ test('coalesce args', function(assert) {
     var c = new Cache('c', 0);
 
     var grids = [];
-    for (var i = 1; i < 50e3; i++) grids.push(Grid.encode({
+    for (var i = 1; i < 10e3; i++) grids.push(Grid.encode({
         id: i,
         x: 0,
         y: 0,


### PR DESCRIPTION
### Problem

- `carmen` currently supports a maximum of 20 query tokens (https://github.com/mapbox/carmen/blob/master/lib/constants.js#L7)
- `carmen-cache` represents the bit mask for subqueries using `unsigned short` which has 16 bits -- so it can at most represent a 16-token query
- What currently happens in some cases is not just bad/empty geocoding, but possibly horrendous resource usage because coalesceMulti relies on this mask check to prevent context cover lists from ballooning out of size (https://github.com/mapbox/carmen-cache/blob/e43612a30bcb37d93170b4b9cbc26facae78581e/src/binding.cpp#L1340)

### This PR

- Adds a unit test that demonstrates how this failed mask check can lead to incorrect results and OOM. Testrun on travis here: https://travis-ci.org/mapbox/carmen-cache/jobs/196437543#L593
- Switches from `unsigned short` to `uint32_t` for all subquery bitmasks in `carmen-cache`

cc @mapbox/geocoding-gang @springmeyer 