### PR TITLE
More careful conversion of objects

### DIFF
--- a/test/coalesce.bench.test.js
+++ b/test/coalesce.bench.test.js
@@ -14,7 +14,8 @@ var mp36 = Math.pow(2,36);
         idx: 0,
         zoom: 14,
         weight: 1,
-        phrase: 3848571113
+        phrase: 3848571113,
+        mask: 1 << 0
     }];
     test('coalesceSingle', function(assert) {
         if (process.env.COVERAGE) return assert.end();

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -57,57 +57,83 @@ test('coalesce args', function(assert) {
         coalesce([valid_subq],undefined,function(){});
     }, /Arg 2 must be an options object/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{idx:-1})],{},function(){});
-    }, /encountered idx value too large to fit/, 'throws');
+    if (process.versions.node[0] != '0') {
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{idx:-1})],{},function(){});
+        }, /encountered idx value too large to fit/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{idx:null})],{},function(){});
-    }, /value must be a number/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{idx:null})],{},function(){});
+        }, /value must be a number/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{zoom:-1})],{},function(){});
-    }, /encountered zoom value too large to fit/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{zoom:-1})],{},function(){});
+        }, /encountered zoom value too large to fit/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{zoom:null})],{},function(){});
-    }, /value must be a number/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{zoom:null})],{},function(){});
+        }, /value must be a number/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{zoom:-1})],{},function(){});
-    }, /encountered zoom value too large to fit/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{zoom:-1})],{},function(){});
+        }, /encountered zoom value too large to fit/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{mask:null})],{},function(){});
-    }, /value must be a number/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{mask:null})],{},function(){});
+        }, /value must be a number/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{mask:-1})],{},function(){});
-    }, /encountered mask value too large to fit/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{mask:-1})],{},function(){});
+        }, /encountered mask value too large to fit/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{weight:null})],{},function(){});
-    }, /weight value must be a number/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{weight:null})],{},function(){});
+        }, /weight value must be a number/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{weight:-1})],{},function(){});
-    }, /encountered weight value too large to fit in double/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{weight:-1})],{},function(){});
+        }, /encountered weight value too large to fit in double/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{phrase:null})],{},function(){});
-    }, /phrase value must be a number/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{phrase:null})],{},function(){});
+        }, /phrase value must be a number/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{phrase:-1})],{},function(){});
-    }, /encountered phrase value too large to fit in uint64_t/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{phrase:-1})],{},function(){});
+        }, /encountered phrase value too large to fit in uint64_t/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{cache:null})],{},function(){});
-    }, /cache value must be a Cache object/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{cache:null})],{},function(){});
+        }, /cache value must be a Cache object/, 'throws');
 
-    assert.throws(function() {
-        coalesce([Object.assign({},valid_subq,{cache:{}})],{},function(){});
-    }, /cache value must be a Cache object/, 'throws');
+        assert.throws(function() {
+            coalesce([Object.assign({},valid_subq,{cache:{}})],{},function(){});
+        }, /cache value must be a Cache object/, 'throws');
+
+        var valid_stack = [
+            {
+                cache: new Cache('a'),
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 0,
+                weight: 0.5,
+                phrase: 1
+            },
+            {
+                cache: new Cache('b'),
+                mask: 1 << 1,
+                idx: 1,
+                zoom: 1,
+                weight: 0.5,
+                phrase: 1
+            }
+        ];
+
+        assert.throws(function() {
+            coalesce(valid_stack.concat([Object.assign({},valid_subq,{cache:null})]),{},function(){});
+        }, /cache value must be a Cache object/, 'throws');
+
+    }
 
     assert.throws(function() {
         coalesce([valid_subq], { bboxzxy:null },function(){} );
@@ -152,29 +178,6 @@ test('coalesce args', function(assert) {
     assert.throws(function() {
         coalesce([valid_subq], { centerzxy:[0,0,0] }, 5 );
     }, /Arg 3 must be a callback/, 'throws');
-
-    var valid_stack = [
-        {
-            cache: new Cache('a'),
-            mask: 1 << 0,
-            idx: 0,
-            zoom: 0,
-            weight: 0.5,
-            phrase: 1
-        },
-        {
-            cache: new Cache('b'),
-            mask: 1 << 1,
-            idx: 1,
-            zoom: 1,
-            weight: 0.5,
-            phrase: 1
-        }
-    ];
-
-    assert.throws(function() {
-        coalesce(valid_stack.concat([Object.assign({},valid_subq,{cache:null})]),{},function(){});
-    }, /cache value must be a Cache object/, 'throws');
 
     assert.throws(function() {
         coalesce([{mask: 1 << 0, idx: 1, zoom: 1, weight: .5, phrase: 1}],{},function(){});

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -6,60 +6,223 @@ var test = require('tape');
 test('coalesce args', function(assert) {
     assert.throws(function() {
         coalesce();
+    }, /Expects 3 arguments/, 'throws');
+
+    assert.throws(function() {
+        coalesce([]);
+    }, /Expects 3 arguments/, 'throws');
+
+    assert.throws(function() {
+        coalesce([], {} );
+    }, /Expects 3 arguments/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{}], {}, function() {} );
+    }, /missing idx property/, 'throws');
+
+    assert.throws(function() {
+        coalesce([-1], {}, function() {} );
+    }, /All items in array must be valid PhrasematchSubq objects/, 'throws');
+
+    assert.throws(function() {
+        coalesce(undefined, {}, function() {} );
     }, /Arg 1 must be a PhrasematchSubq array/, 'throws');
 
     assert.throws(function() {
-        coalesce([
-            {
-                cache: new Cache('a'),
-                mask: 1 << 0,
-                idx: 0,
-                zoom: 0,
-                weight: 0.5,
-                phrase: 1
-            },
-            {
-                cache: new Cache('b'),
-                mask: 1 << 1,
-                idx: 1,
-                zoom: 1,
-                weight: 0.5,
-                phrase: 1
-            },
-        ]);
+        coalesce([], {}, function() {} );
+    }, /Arg 1 must be an array with one or more/, 'throws');
+
+    assert.throws(function() {
+        coalesce([undefined], {}, function() {} );
+    }, /All items in array must be valid PhrasematchSubq objects/, 'throws');
+
+    assert.throws(function() {
+        coalesce([null], {}, function() {} );
+    }, /All items in array must be valid PhrasematchSubq objects/, 'throws');
+
+    var valid_subq = {
+             cache: new Cache('a'),
+             mask: 1 << 0,
+             idx: 0,
+             zoom: 2,
+             weight: 1,
+             phrase: 1
+    };
+
+    assert.throws(function() {
+        coalesce([valid_subq],undefined,function(){});
     }, /Arg 2 must be an options object/, 'throws');
 
     assert.throws(function() {
-        coalesce([], { centerzxy:[0,0,0] } );
-    }, /Arg 3 must be a callback/, 'throws');
+        coalesce([valid_subq],undefined,function(){});
+    }, /Arg 2 must be an options object/, 'throws');
 
     assert.throws(function() {
-        coalesce([-1]);
-    }, /All items in array must be valid/, 'throws');
-
-    assert.throws(function() {
-        coalesce([undefined]);
-    }, /All items in array must be valid/, 'throws');
-
-    assert.throws(function() {
-        coalesce([{idx:-1}]);
+        coalesce([Object.assign({},valid_subq,{idx:-1})],{},function(){});
     }, /encountered idx value too large to fit/, 'throws');
 
     assert.throws(function() {
-        coalesce([{zoom:-1}]);
+        coalesce([Object.assign({},valid_subq,{idx:null})],{},function(){});
+    }, /value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{zoom:-1})],{},function(){});
     }, /encountered zoom value too large to fit/, 'throws');
 
     assert.throws(function() {
-        coalesce([], { centerzxy:[-1,0,0] } );
-    }, /value in array too large/, 'throws');
+        coalesce([Object.assign({},valid_subq,{zoom:null})],{},function(){});
+    }, /value must be a number/, 'throws');
 
     assert.throws(function() {
-        coalesce([], { centerzxy:[4294967296,0,0] } );
-    }, /value in array too large/, 'throws');
+        coalesce([Object.assign({},valid_subq,{zoom:-1})],{},function(){});
+    }, /encountered zoom value too large to fit/, 'throws');
 
     assert.throws(function() {
-        coalesce([], { centerzxy:[0,0,0] }, 5 );
+        coalesce([Object.assign({},valid_subq,{mask:null})],{},function(){});
+    }, /value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{mask:-1})],{},function(){});
+    }, /encountered mask value too large to fit/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{weight:null})],{},function(){});
+    }, /weight value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{weight:-1})],{},function(){});
+    }, /encountered weight value too large to fit in double/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{phrase:null})],{},function(){});
+    }, /phrase value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{phrase:-1})],{},function(){});
+    }, /encountered phrase value too large to fit in uint64_t/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{cache:null})],{},function(){});
+    }, /cache value must be a Cache object/, 'throws');
+
+    assert.throws(function() {
+        coalesce([Object.assign({},valid_subq,{cache:{}})],{},function(){});
+    }, /cache value must be a Cache object/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { bboxzxy:null },function(){} );
+    }, /bboxzxy must be an array/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { bboxzxy:[0,0,0,0] },function(){} );
+    }, /bboxzxy must be an array of 5 numbers/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { bboxzxy:['',0,0,0,0] },function(){} );
+    }, /bboxzxy values must be number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { bboxzxy:[-1,0,0,0,0] },function(){} );
+    }, /encountered bboxzxy value too large to fit in uint32_t/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { bboxzxy:[4294967296,0,0,0,0] },function(){} );
+    }, /encountered bboxzxy value too large to fit in uint32_t/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { centerzxy:null },function(){} );
+    }, /centerzxy must be an array/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { centerzxy:['',0,0] },function(){} );
+    }, /centerzxy values must be number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { centerzxy:[0,0] },function(){} );
+    }, /centerzxy must be an array of 3 numbers/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { centerzxy:[-1,0,0] },function(){} );
+    }, /encountered centerzxy value too large to fit in uint32_t/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { centerzxy:[4294967296,0,0] },function(){} );
+    }, /encountered centerzxy value too large to fit in uint32_t/, 'throws');
+
+    assert.throws(function() {
+        coalesce([valid_subq], { centerzxy:[0,0,0] }, 5 );
     }, /Arg 3 must be a callback/, 'throws');
+
+    var valid_stack = [
+        {
+            cache: new Cache('a'),
+            mask: 1 << 0,
+            idx: 0,
+            zoom: 0,
+            weight: 0.5,
+            phrase: 1
+        },
+        {
+            cache: new Cache('b'),
+            mask: 1 << 1,
+            idx: 1,
+            zoom: 1,
+            weight: 0.5,
+            phrase: 1
+        }
+    ];
+
+    assert.throws(function() {
+        coalesce(valid_stack.concat([Object.assign({},valid_subq,{cache:null})]),{},function(){});
+    }, /cache value must be a Cache object/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{mask: 1 << 0, idx: 1, zoom: 1, weight: .5, phrase: 1}],{},function(){});
+    }, /missing/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), idx: 1, zoom: 1, weight: .5, phrase: 1}],{},function(){});
+    }, /missing/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: 1}],{},function(){});
+    }, /missing/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: 1}],{},function(){});
+    }, /missing/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: 1}],{},function(){});
+    }, /missing/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5}],{},function(){});
+    }, /missing/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: '', mask: 1 << 0, idx: 1, weight: .5,  zoom: 1, phrase: 1}],{},function(){});
+    }, /cache value must be a Cache object/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: 1}],{},function(){});
+    }, /mask value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: 1}],{},function(){});
+    }, /idx value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: 1}],{},function(){});
+    }, /zoom value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: 1}],{},function(){});
+    }, /weight value must be a number/, 'throws');
+
+    assert.throws(function() {
+        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: 1, phrase: ''}],{},function(){});
+    }, /phrase value must be a number/, 'throws');
 
     assert.end();
 });


### PR DESCRIPTION
This fixes three potential crashes and adds more test coverage.

  - #85 (SIGILL)
  - #83 (SIGABRT)
  - #81 (SIGSEGV)

It also refactors to remove the freestanding functions that took `v8::Local` objects as arguments. This is because these functions may need `HandleScopes` if not fully inlined. Therefore manually inlining them avoids a potential leak if the inlining does not happen.