### PR TITLE
[rocksdb] Fix source compile with recent ubuntu

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -3,6 +3,11 @@
     'default_configuration': 'Release',
     'cflags_cc' : [
       '-std=c++14',
+      # mason packages are built/linked with the CXX11_ABI=0 (currently)
+      # so we need to link this way too. This allows source
+      # compiling carmen-cache on any ubuntu version, even latest
+      # where the CXX11_ABI default has flipped to 1
+      '-D_GLIBCXX_USE_CXX11_ABI=0'
     ],
     'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
     'configurations': {


### PR DESCRIPTION
Mason packages default to `D_GLIBCXX_USE_CXX11_ABI=0` for full capability across all linux versions pre and post the dubious duel-abi change (https://gcc.gnu.org/onlinedocs/libstdc%2B%2B/manual/using_dual_abi.html).

Recent ubuntu versions start defaulting to `D_GLIBCXX_USE_CXX11_ABI=1` so to ensure we can link correctly we need to set the default to `0` for the carmen cache compile. In the future mason may provide "duel" packages for both versions, maybe. Until then this is the way forward to ensure you can source compile on a recent ubuntu version.

@apendleton feel free to point this at the right rocksdb base.

/cc @yhahn 