### PR TITLE
Language fields (for carmen@hyperpolyglot)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,11 @@ matrix:
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.10" # node abi 11
-     - os: linux
-       compiler: clang
        env: NODE_VERSION="4" # node abi 46
      - os: linux
        compiler: clang
        env: NODE_VERSION="6" # node abi 48
      # OS X
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="0.10" # node abi 11
-       osx_image: xcode8.2
      - os: osx
        compiler: clang
        env: NODE_VERSION="4" # node abi 46

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git", 
     "type": "git"
   }, 
-  "version": "0.17.0-lang-fields-1",
+  "version": "0.17.0-lang-fields-2",
   "dependencies": {
     "node-pre-gyp": "~0.6.32", 
     "nan": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git", 
     "type": "git"
   }, 
-  "version": "0.17.0",
+  "version": "0.17.0-lang-fields-1",
   "dependencies": {
     "node-pre-gyp": "~0.6.32", 
     "nan": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git", 
     "type": "git"
   }, 
-  "version": "0.17.0-lang-fields-2",
+  "version": "0.17.0-lang-fields-shorter-1",
   "dependencies": {
     "node-pre-gyp": "~0.6.32", 
     "nan": "~2.5.1",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1341,8 +1341,8 @@ void coalesceSingle(uv_work_t* req) {
         // Load and concatenate grids for all ids in `phrases`
         intarray grids;
         grids = subq.type == TYPE_MEMORY ?
-            __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES) :
-            __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES);
+            __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, subq.prefix, baton->langfield) :
+            __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, subq.prefix, baton->langfield);
 
         unsigned long m = grids.size();
         double relevMax = 0;
@@ -1494,8 +1494,8 @@ void coalesceMulti(uv_work_t* req) {
             // Load and concatenate grids for all ids in `phrases`
             intarray grids;
             grids = subq.type == TYPE_MEMORY ?
-                __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES) :
-                __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES);
+                __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, subq.prefix, baton->langfield) :
+                __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, subq.prefix, baton->langfield);
 
             bool first = i == 0;
             bool last = i == (stack.size() - 1);

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -70,8 +70,9 @@ intarray __get(MemoryCache const* c, std::string phrase, langfield_type langfiel
     add_langfield(phrase, langfield);
     arraycache::const_iterator aitr = cache.find(phrase);
     if (aitr != cache.end()) {
-        return aitr->second;
+        array = aitr->second;
     }
+    std::sort(array.begin(), array.end(), std::greater<uint64_t>());
     return array;
 }
 
@@ -641,6 +642,8 @@ void mergeQueue(uv_work_t* req) {
             }
 
             std::string in_message2;
+            std::string max_key = "__MAX__";
+            auto max_key_length = max_key.length();
             rocksdb::Status s = db2->Get(rocksdb::ReadOptions(), key_id, &in_message2);
             if (s.ok()) {
                 // get input proto 2
@@ -651,7 +654,7 @@ void mergeQueue(uv_work_t* req) {
                 lastval = 0;
                 for (auto it = vals2.first; it != vals2.second; ++it) {
                     if (method == "freq") {
-                        if (key_id == "__MAX__") {
+                        if (key_id.compare(0, max_key_length, max_key) == 0) {
                             varr[0] = varr[0] > *it ? varr[0] : *it;
                         } else {
                             varr[0] = varr[0] + *it;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1340,15 +1340,9 @@ void coalesceSingle(uv_work_t* req) {
 
         // Load and concatenate grids for all ids in `phrases`
         intarray grids;
-        if (subq.prefix) {
-            grids = subq.type == TYPE_MEMORY ?
-                __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, true, ALL_LANGUAGES) :
-                __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, true, ALL_LANGUAGES);
-        } else {
-            grids = subq.type == TYPE_MEMORY ?
-                __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, false, ALL_LANGUAGES) :
-                __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, false, ALL_LANGUAGES);
-        }
+        grids = subq.type == TYPE_MEMORY ?
+            __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES) :
+            __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES);
 
         unsigned long m = grids.size();
         double relevMax = 0;
@@ -1499,15 +1493,9 @@ void coalesceMulti(uv_work_t* req) {
         for (auto const& subq : stack) {
             // Load and concatenate grids for all ids in `phrases`
             intarray grids;
-            if (subq.prefix) {
-                grids = subq.type == TYPE_MEMORY ?
-                    __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, true, ALL_LANGUAGES) :
-                    __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, true, ALL_LANGUAGES);
-            } else {
-                grids = subq.type == TYPE_MEMORY ?
-                    __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, false, ALL_LANGUAGES) :
-                    __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, false, ALL_LANGUAGES);
-            }
+            grids = subq.type == TYPE_MEMORY ?
+                __getmatching(reinterpret_cast<MemoryCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES) :
+                __getmatching(reinterpret_cast<RocksDBCache*>(subq.cache), subq.phrase, subq.prefix, ALL_LANGUAGES);
 
             bool first = i == 0;
             bool last = i == (stack.size() - 1);

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -735,7 +735,17 @@ NAN_METHOD(MemoryCache::list)
 
         unsigned idx = 0;
         for (auto const& item : c->cache_) {
-            ids->Set(idx++,Nan::New(item.first).ToLocalChecked());
+            Local<Array> out = Nan::New<Array>();
+            out->Set(0, Nan::New(item.first.substr(0, item.first.find(LANGFIELD_SEPARATOR))).ToLocalChecked());
+
+            langfield_type langfield = extract_langfield(item.first);
+            if (langfield == ALL_LANGUAGES) {
+                out->Set(1, Nan::Null());
+            } else {
+                out->Set(1, langfieldToLangarray(langfield));
+            }
+
+            ids->Set(idx++, out);
         }
 
         info.GetReturnValue().Set(ids);
@@ -760,7 +770,18 @@ NAN_METHOD(RocksDBCache::list)
         for (it->SeekToFirst(); it->Valid(); it->Next()) {
             std::string key_id = it->key().ToString();
             if (key_id.at(0) == '=') continue;
-            ids->Set(idx++, Nan::New(key_id).ToLocalChecked());
+
+            Local<Array> out = Nan::New<Array>();
+            out->Set(0, Nan::New(key_id.substr(0, key_id.find(LANGFIELD_SEPARATOR))).ToLocalChecked());
+
+            langfield_type langfield = extract_langfield(key_id);
+            if (langfield == ALL_LANGUAGES) {
+                out->Set(1, Nan::Null());
+            } else {
+                out->Set(1, langfieldToLangarray(langfield));
+            }
+
+            ids->Set(idx++, out);
         }
 
         info.GetReturnValue().Set(ids);

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -379,28 +379,23 @@ NAN_METHOD(MemoryCache::pack)
                 std::string prefix_t2 = "";
 
                 // add this to the memoized prefix array too, maybe
-                auto item_length = item.first.length();
-                if (item.first.at(item_length - 1) == '.') {
-                    // this is an entry that bans degens
-                    // so only include it if it itself smaller than the
-                    // prefix limit (minus dot), and leave it dot-suffixed
-                    if (item_length <= (MEMO_PREFIX_LENGTH_T1 + 1)) {
-                        prefix_t1 = "=1" + item.first;
-                    } else if (item_length > (MEMO_PREFIX_LENGTH_T1 + 1) && item_length <= (MEMO_PREFIX_LENGTH_T2 + 1)) {
-                        prefix_t2 = "=2" + item.first;
-                    }
+                auto phrase_length = item.first.find(LANGFIELD_SEPARATOR);
+                // use the full string for things shorter than the limit
+                // or the prefix otherwise
+                if (phrase_length < MEMO_PREFIX_LENGTH_T1) {
+                    prefix_t1 = "=1" + item.first;
                 } else {
-                    // use the full string for things shorter than the limit
-                    // or the prefix otherwise
-                    if (item_length < MEMO_PREFIX_LENGTH_T1) {
-                        prefix_t1 = "=1" + item.first;
+                    // get the prefix, then append the langfield back onto it again
+                    langfield_type langfield = extract_langfield(item.first);
+
+                    prefix_t1 = "=1" + item.first.substr(0, MEMO_PREFIX_LENGTH_T1);
+                    add_langfield(prefix_t1, langfield);
+
+                    if (phrase_length < MEMO_PREFIX_LENGTH_T2) {
+                        prefix_t2 = "=2" + item.first;
                     } else {
-                        prefix_t1 = "=1" + item.first.substr(0, MEMO_PREFIX_LENGTH_T1);
-                        if (item_length < MEMO_PREFIX_LENGTH_T2) {
-                            prefix_t2 = "=2" + item.first;
-                        } else {
-                            prefix_t2 = "=2" + item.first.substr(0, MEMO_PREFIX_LENGTH_T2);
-                        }
+                        prefix_t2 = "=2" + item.first.substr(0, MEMO_PREFIX_LENGTH_T2);
+                        add_langfield(prefix_t2, langfield);
                     }
                 }
 

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -95,7 +95,7 @@ public:
 #define MEMO_PREFIX_LENGTH_T2 7
 #define PREFIX_MAX_GRID_LENGTH 500000
 
-#define ALL_LANGUAGES std::numeric_limits<unsigned __int128>::max()
+constexpr langfield_type ALL_LANGUAGES = ~(langfield_type)(0);
 #define LANGFIELD_SEPARATOR '|'
 
 #define TYPE_MEMORY 1

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -91,8 +91,8 @@ public:
 #define CACHE_MESSAGE 1
 #define CACHE_ITEM 1
 
-#define MEMO_PREFIX_LENGTH_T1 4
-#define MEMO_PREFIX_LENGTH_T2 7
+#define MEMO_PREFIX_LENGTH_T1 3
+#define MEMO_PREFIX_LENGTH_T2 6
 #define PREFIX_MAX_GRID_LENGTH 500000
 
 constexpr langfield_type ALL_LANGUAGES = ~(langfield_type)(0);

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -28,6 +28,8 @@
 #include <tuple>
 
 #include <cassert>
+#include <cstring>
+
 #include "rocksdb/db.h"
 
 namespace carmen {

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <vector>
 #include <deque>
+#include <limits>
 #include <algorithm>
 #include "radix_max_heap.h"
 #pragma clang diagnostic pop
@@ -42,6 +43,7 @@ protected:
 
 typedef std::string key_type;
 typedef uint64_t value_type;
+typedef unsigned __int128 langfield_type;
 // fully cached item
 typedef std::vector<value_type> intarray;
 typedef std::vector<key_type> keyarray;
@@ -56,7 +58,7 @@ public:
     static NAN_METHOD(pack);
     static NAN_METHOD(list);
     static NAN_METHOD(_get);
-    static NAN_METHOD(_getbyprefix);
+    static NAN_METHOD(_getmatching);
     static NAN_METHOD(_set);
     static NAN_METHOD(coalesce);
     explicit MemoryCache();
@@ -75,7 +77,7 @@ public:
     static NAN_METHOD(merge);
     static NAN_METHOD(list);
     static NAN_METHOD(_get);
-    static NAN_METHOD(_getbyprefix);
+    static NAN_METHOD(_getmatching);
     static NAN_METHOD(_set);
     static NAN_METHOD(coalesce);
     explicit RocksDBCache();
@@ -90,6 +92,9 @@ public:
 #define MEMO_PREFIX_LENGTH_T1 4
 #define MEMO_PREFIX_LENGTH_T2 7
 #define PREFIX_MAX_GRID_LENGTH 500000
+
+#define ALL_LANGUAGES std::numeric_limits<unsigned __int128>::max()
+#define LANGFIELD_SEPARATOR '|'
 
 #define TYPE_MEMORY 1
 #define TYPE_ROCKSDB 2

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -12,6 +12,10 @@ var sorted = function(arr) {
     return [].concat(arr).sort();
 }
 
+var sortedDescending = function(arr) {
+    return [].concat(arr).sort(function (a, b) { return b - a; });
+}
+
 tape('list', function(assert) {
     var cache = new carmenCache.MemoryCache('a');
     cache._set('5', [0,1,2]);
@@ -29,11 +33,11 @@ tape('get / set / list / pack / load (simple)', function(assert) {
 
         assert.deepEqual(cache._get(id), undefined, id + ' not set');
         cache._set(id, [0,1,2]);
-        assert.deepEqual(cache._get(id), [0, 1, 2], id + ' set to 0,1,2');
+        assert.deepEqual(cache._get(id), sortedDescending([0, 1, 2]), id + ' set to 0,1,2');
         cache._set(id, [3,4,5]);
-        assert.deepEqual(cache._get(id), [3, 4, 5], id + ' set to 3,4,5');
+        assert.deepEqual(cache._get(id), sortedDescending([3, 4, 5]), id + ' set to 3,4,5');
         cache._set(id, [6,7,8], null, true);
-        assert.deepEqual(cache._get(id), [3, 4, 5, 6, 7, 8], id + ' set to 3,4,5,6,7,8');
+        assert.deepEqual(cache._get(id), sortedDescending([3, 4, 5, 6, 7, 8]), id + ' set to 3,4,5,6,7,8');
     }
 
     assert.deepEqual(sorted(cache.list().map(function(x) { return x[0]; })), sorted(ids), "mem ids match");
@@ -45,7 +49,7 @@ tape('get / set / list / pack / load (simple)', function(assert) {
     for (var i = 0; i < 5; i++) {
         var id = ids[i];
 
-        assert.deepEqual(cache._get(id), [3, 4, 5, 6, 7, 8], id + ' set to 3,4,5,6,7,8');
+        assert.deepEqual(cache._get(id), sortedDescending([3, 4, 5, 6, 7, 8]), id + ' set to 3,4,5,6,7,8');
     }
 
     assert.deepEqual(sorted(loader.list().map(function(x) { return x[0]; })), sorted(ids), "rocks ids match");
@@ -65,16 +69,16 @@ tape('get / set / list / pack / load (with lang codes)', function(assert) {
         cache._set(id, [0,1,2], [0]);
         cache._set(id, [7,8,9], [1]);
         cache._set(id, [12,13,14], [0,1]);
-        assert.deepEqual(cache._get(id, [0]), [0, 1, 2], id + ' for lang [0] set to 0,1,2');
-        assert.deepEqual(cache._get(id, [1]), [7, 8, 9], id + ' for lang [1] set to 7,8,9');
-        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] set to 12,13,14');
+        assert.deepEqual(cache._get(id, [0]), sortedDescending([0, 1, 2]), id + ' for lang [0] set to 0,1,2');
+        assert.deepEqual(cache._get(id, [1]), sortedDescending([7, 8, 9]), id + ' for lang [1] set to 7,8,9');
+        assert.deepEqual(cache._get(id, [0,1]), sortedDescending([12, 13, 14]), id + ' for lang [0,1] set to 12,13,14');
         assert.false(cache._get(id), id + ' without lang code returns nothing');
         cache._set(id, [3,4,5], [0]);
-        assert.deepEqual(cache._get(id, [0]), [3,4,5], id + ' for lang [0] set to 3,4,5');
-        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] still set to 12,13,14');
+        assert.deepEqual(cache._get(id, [0]), sortedDescending([3,4,5]), id + ' for lang [0] set to 3,4,5');
+        assert.deepEqual(cache._get(id, [0,1]), sortedDescending([12, 13, 14]), id + ' for lang [0,1] still set to 12,13,14');
         cache._set(id, [6,7,8], [0], true);
-        assert.deepEqual(cache._get(id, [0]), [3, 4, 5, 6, 7, 8], id + ' for lang [0] set to 3,4,5,6,7,8');
-        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] still set to 12,13,14');
+        assert.deepEqual(cache._get(id, [0]), sortedDescending([3, 4, 5, 6, 7, 8]), id + ' for lang [0] set to 3,4,5,6,7,8');
+        assert.deepEqual(cache._get(id, [0,1]), sortedDescending([12, 13, 14]), id + ' for lang [0,1] still set to 12,13,14');
         assert.false(cache._get(id), id + ' without lang code still returns nothing');
 
         expected.push([id, [0]]);
@@ -91,11 +95,11 @@ tape('get / set / list / pack / load (with lang codes)', function(assert) {
     for (var i = 0; i < 5; i++) {
         var id = ids[i];
 
-        assert.deepEqual(cache._get(id, [1]), [7, 8, 9], id + ' for lang [1] set to 7,8,9');
-        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] set to 12,13,14');
+        assert.deepEqual(cache._get(id, [1]), sortedDescending([7, 8, 9]), id + ' for lang [1] set to 7,8,9');
+        assert.deepEqual(cache._get(id, [0,1]), sortedDescending([12, 13, 14]), id + ' for lang [0,1] set to 12,13,14');
         assert.false(cache._get(id), id + ' without lang code returns nothing');
-        assert.deepEqual(cache._get(id, [0]), [3, 4, 5, 6, 7, 8], id + ' for lang [0] set to 3,4,5,6,7,8');
-        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] still set to 12,13,14');
+        assert.deepEqual(cache._get(id, [0]), sortedDescending([3, 4, 5, 6, 7, 8]), id + ' for lang [0] set to 3,4,5,6,7,8');
+        assert.deepEqual(cache._get(id, [0,1]), sortedDescending([12, 13, 14]), id + ' for lang [0,1] still set to 12,13,14');
     }
 
     assert.deepEqual(sorted(cache.list().map(JSON.stringify)), sorted(expected.map(JSON.stringify)), "rocks ids and langs match");
@@ -111,7 +115,7 @@ tape('pack', function(assert) {
 
     // fake data
     var array = [];
-    for (var i=0;i<10000;++i) array.push(0);
+    for (var i=0;i<10000;++i) array.push(i);
 
     // now test packing data created via load
     var packer = new carmenCache.MemoryCache('a');
@@ -130,8 +134,8 @@ tape('pack', function(assert) {
     var directLoad = tmpfile();
     packer.pack(directLoad)
     var loader = new carmenCache.RocksDBCache('a', directLoad);
-    assert.deepEqual(loader._get('5'), array);
-    assert.deepEqual(loader._get('6'), array);
+    assert.deepEqual(loader._get('5'), sortedDescending(array));
+    assert.deepEqual(loader._get('6'), sortedDescending(array));
 
     assert.end();
 });

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -8,31 +8,101 @@ fs.mkdirSync(tmpdir);
 var tmpidx = 0;
 var tmpfile = function() { return tmpdir + "/" + (tmpidx++) + ".dat"; };
 
-tape('#list', function(assert) {
+var sorted = function(arr) {
+    return [].concat(arr).sort();
+}
+
+tape('list', function(assert) {
     var cache = new carmenCache.MemoryCache('a');
     cache._set('5', [0,1,2]);
-    assert.deepEqual(cache.list(), ['5']);
+    assert.deepEqual(cache.list().map(function(x) { return x[0]; }), ['5']);
     assert.end();
 });
 
-tape('#get + #set', function(assert) {
+tape('get / set / list / pack / load (simple)', function(assert) {
     var cache = new carmenCache.MemoryCache('a');
 
+    var ids = [];
     for (var i = 0; i < 5; i++) {
         var id = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+        ids.push(id);
+
         assert.deepEqual(cache._get(id), undefined, id + ' not set');
         cache._set(id, [0,1,2]);
         assert.deepEqual(cache._get(id), [0, 1, 2], id + ' set to 0,1,2');
         cache._set(id, [3,4,5]);
         assert.deepEqual(cache._get(id), [3, 4, 5], id + ' set to 3,4,5');
-        cache._set(id, [6,7,8], true);
+        cache._set(id, [6,7,8], null, true);
         assert.deepEqual(cache._get(id), [3, 4, 5, 6, 7, 8], id + ' set to 3,4,5,6,7,8');
     }
 
+    assert.deepEqual(sorted(cache.list().map(function(x) { return x[0]; })), sorted(ids), "mem ids match");
+
+    var pack = tmpfile();
+    cache.pack(pack);
+    var loader = new carmenCache.RocksDBCache('b', pack);
+
+    for (var i = 0; i < 5; i++) {
+        var id = ids[i];
+
+        assert.deepEqual(cache._get(id), [3, 4, 5, 6, 7, 8], id + ' set to 3,4,5,6,7,8');
+    }
+
+    assert.deepEqual(sorted(loader.list().map(function(x) { return x[0]; })), sorted(ids), "rocks ids match");
     assert.end();
 });
 
-tape('#pack', function(assert) {
+tape('get / set / list / pack / load (with lang codes)', function(assert) {
+    var cache = new carmenCache.MemoryCache('a');
+
+    var ids = [];
+    var expected = [];
+    for (var i = 0; i < 5; i++) {
+        var id = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+        ids.push(id);
+
+        assert.deepEqual(cache._get(id), undefined, id + ' not set');
+        cache._set(id, [0,1,2], [0]);
+        cache._set(id, [7,8,9], [1]);
+        cache._set(id, [12,13,14], [0,1]);
+        assert.deepEqual(cache._get(id, [0]), [0, 1, 2], id + ' for lang [0] set to 0,1,2');
+        assert.deepEqual(cache._get(id, [1]), [7, 8, 9], id + ' for lang [1] set to 7,8,9');
+        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] set to 12,13,14');
+        assert.false(cache._get(id), id + ' without lang code returns nothing');
+        cache._set(id, [3,4,5], [0]);
+        assert.deepEqual(cache._get(id, [0]), [3,4,5], id + ' for lang [0] set to 3,4,5');
+        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] still set to 12,13,14');
+        cache._set(id, [6,7,8], [0], true);
+        assert.deepEqual(cache._get(id, [0]), [3, 4, 5, 6, 7, 8], id + ' for lang [0] set to 3,4,5,6,7,8');
+        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] still set to 12,13,14');
+        assert.false(cache._get(id), id + ' without lang code still returns nothing');
+
+        expected.push([id, [0]]);
+        expected.push([id, [1]]);
+        expected.push([id, [0,1]]);
+    }
+
+    assert.deepEqual(sorted(cache.list().map(JSON.stringify)), sorted(expected.map(JSON.stringify)), "mem ids and langs match");
+
+    var pack = tmpfile();
+    cache.pack(pack);
+    var loader = new carmenCache.RocksDBCache('b', pack);
+
+    for (var i = 0; i < 5; i++) {
+        var id = ids[i];
+
+        assert.deepEqual(cache._get(id, [1]), [7, 8, 9], id + ' for lang [1] set to 7,8,9');
+        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] set to 12,13,14');
+        assert.false(cache._get(id), id + ' without lang code returns nothing');
+        assert.deepEqual(cache._get(id, [0]), [3, 4, 5, 6, 7, 8], id + ' for lang [0] set to 3,4,5,6,7,8');
+        assert.deepEqual(cache._get(id, [0,1]), [12, 13, 14], id + ' for lang [0,1] still set to 12,13,14');
+    }
+
+    assert.deepEqual(sorted(cache.list().map(JSON.stringify)), sorted(expected.map(JSON.stringify)), "rocks ids and langs match");
+    assert.end();
+});
+
+tape('pack', function(assert) {
     var cache = new carmenCache.MemoryCache('a');
     cache._set('5', [0,1,2]);
     // set should replace data
@@ -63,66 +133,5 @@ tape('#pack', function(assert) {
     assert.deepEqual(loader._get('5'), array);
     assert.deepEqual(loader._get('6'), array);
 
-    assert.end();
-});
-
-tape('#load', function(assert) {
-    var cache = new carmenCache.MemoryCache('a');
-    assert.equal(cache.id, 'a');
-
-    assert.equal(cache._get('5'), undefined);
-    assert.deepEqual(cache.list(), []);
-
-    cache._set('5', [0,1,2]);
-    assert.deepEqual(cache._get('5'), [0,1,2]);
-    assert.deepEqual(cache.list(), ['5']);
-
-    cache._set('21', [5,6]);
-    assert.deepEqual(cache._get('21'), [5,6]);
-    assert.deepEqual(cache.list(), ['21', '5'], 'keys in type');
-
-    // cache A serializes data, cache B loads serialized data.
-    var pack = tmpfile();
-    cache.pack(pack);
-    var loader = new carmenCache.RocksDBCache('b', pack);
-    assert.deepEqual(loader._get('21'), [6,5]);
-    assert.deepEqual(loader.list(), ['21', '5'], 'keys in shard');
-    assert.end();
-});
-
-tape('#dot suffix', function(assert) {
-    var cache = new carmenCache.MemoryCache('mem');
-
-    cache._set('test', [2,1,0]);
-    cache._set('test.', [7,6,5,4]);
-    cache._set('something', [4,3,2]);
-    cache._set('else.', [9,8,7]);
-
-    // cache A serializes data, cache B loads serialized data.
-    var pack = tmpfile();
-    cache.pack(pack);
-    var loader = new carmenCache.RocksDBCache('packed', pack);
-
-    [cache, loader].forEach(function(c) {
-        assert.deepEqual(c._get('test'), [2,1,0], 'exact get without dot where both exist for ' + c.id);
-        assert.deepEqual(c._get('test.'), [7,6,5,4], 'exact get with dot where both exist for ' + c.id);
-        assert.deepEqual(c._get('something'), [4,3,2], 'exact get without dot where non-dot exists for ' + c.id);
-        assert.deepEqual(c._get('something.'), undefined, 'exact get with dot where non-dot exists for ' + c.id);
-        assert.deepEqual(c._get('else'), undefined, 'exact get without dot where dot exists for ' + c.id);
-        assert.deepEqual(c._get('else.'), [9,8,7], 'exact get with dot where dot exists for ' + c.id);
-
-        assert.deepEqual(c._get('test', true), [7,6,5,4,2,1,0], 'ignore-prefix get where both exist for ' + c.id);
-        assert.deepEqual(c._get('something', true), [4,3,2], 'ignore-prefix get where non-dot exists for ' + c.id);
-        assert.deepEqual(c._get('else', true), [9,8,7], 'ignore-prefix get where dot exists for ' + c.id);
-
-        assert.deepEqual(c._getByPrefix('te'), [2,1,0], 'partial getbyprefix where both exist for ' + c.id);
-        assert.deepEqual(c._getByPrefix('test'), [7,6,5,4,2,1,0], 'complete getbyprefix where both exist for ' + c.id);
-        assert.deepEqual(c._getByPrefix('so'), [4,3,2], 'partial getbyprefix where non-dot exists for ' + c.id);
-        assert.deepEqual(c._getByPrefix('something'), [4,3,2], 'complete getbyprefix where non-dot exists for ' + c.id);
-        assert.deepEqual(c._getByPrefix('el'), undefined, 'partial getbyprefix where dot exists for ' + c.id);
-        assert.deepEqual(c._getByPrefix('else'), [9,8,7], 'complete getbyprefix where dot exists for ' + c.id);
-    });
-
-    assert.deepEqual(loader.list('grid'), [ 'else.', 'something', 'test', 'test.' ], 'keys in shard');
     assert.end();
 });

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -448,7 +448,8 @@ test('coalesce args', function(assert) {
                 weight: 1,
                 phrase: '1',
                 prefix: false,
-            }], {languages: [0]}, function(err, res) {
+                languages: [0]
+            }], {}, function(err, res) {
                 assert.ifError(err);
                 assert.equal(res.length, 4);
                 assert.deepEqual(res[0].relev, 1, '0.relev');
@@ -471,7 +472,8 @@ test('coalesce args', function(assert) {
                 weight: 1,
                 phrase: '1',
                 prefix: false,
-            }], {languages: [3]}, function(err, res) {
+                languages: [3]
+            }], {}, function(err, res) {
                 assert.ifError(err);
                 assert.equal(res.length, 4);
                 assert.deepEqual(res[0].relev, 0.8, '0.relev');
@@ -683,7 +685,8 @@ test('coalesce args', function(assert) {
                 weight: 0.5,
                 phrase: '1',
                 prefix: false,
-            }], {languages: [0]}, function(err, res) {
+                languages: [0]
+            }], {}, function(err, res) {
                 assert.ifError(err);
                 // sorts by relev, score
                 assert.deepEqual(res[0].relev, 1, '0.relev');
@@ -713,7 +716,8 @@ test('coalesce args', function(assert) {
                 weight: 0.5,
                 phrase: '1',
                 prefix: false,
-            }], {languages: [3]}, function(err, res) {
+                languages: [3]
+            }], {}, function(err, res) {
                 assert.ifError(err);
                 // sorts by relev, score
                 assert.deepEqual(res[0].relev, 0.9, '0.relev');

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -1,7 +1,20 @@
-var Cache = require('../index.js').MemoryCache;
+var MemoryCache = require('../index.js').MemoryCache;
+var RocksDBCache = require('../index.js').RocksDBCache;
 var Grid = require('./grid.js');
 var coalesce = require('../index.js').coalesce;
 var test = require('tape');
+var fs = require('fs');
+
+var tmpdir = "/tmp/temp." + Math.random().toString(36).substr(2, 5);
+fs.mkdirSync(tmpdir);
+var tmpidx = 0;
+var tmpfile = function() { return tmpdir + "/" + (tmpidx++) + ".dat"; };
+
+var toRocksCache = function(memcache) {
+    var pack = tmpfile();
+    memcache.pack(pack);
+    return new RocksDBCache(memcache.id + ".rocks", pack);
+}
 
 test('coalesce args', function(assert) {
     assert.throws(function() {
@@ -41,7 +54,7 @@ test('coalesce args', function(assert) {
     }, /All items in array must be valid PhrasematchSubq objects/, 'throws');
 
     var valid_subq = {
-        cache: new Cache('a'),
+        cache: new MemoryCache('a'),
         mask: 1 << 0,
         idx: 0,
         zoom: 2,
@@ -113,7 +126,7 @@ test('coalesce args', function(assert) {
 
         var valid_stack = [
             {
-                cache: new Cache('a'),
+                cache: new MemoryCache('a'),
                 mask: 1 << 0,
                 idx: 0,
                 zoom: 0,
@@ -122,7 +135,7 @@ test('coalesce args', function(assert) {
                 prefix: false,
             },
             {
-                cache: new Cache('b'),
+                cache: new MemoryCache('b'),
                 mask: 1 << 1,
                 idx: 1,
                 zoom: 1,
@@ -187,23 +200,23 @@ test('coalesce args', function(assert) {
     }, /missing/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
     }, /missing/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
     }, /missing/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
     }, /missing/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: '1', prefix: false}],{},function(){});
     }, /missing/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5, prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5, prefix: false}],{},function(){});
     }, /missing/, 'throws');
 
     assert.throws(function() {
@@ -211,31 +224,31 @@ test('coalesce args', function(assert) {
     }, /cache value must be a Cache object/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false}],{},function(){});
     }, /mask value must be a number/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: '1', prefix: false}],{},function(){});
     }, /idx value must be a number/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: '1', prefix: false}],{},function(){});
     }, /zoom value must be a number/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: '1', prefix: false}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: '1', prefix: false}],{},function(){});
     }, /weight value must be a number/, 'throws');
 
     assert.throws(function() {
-        coalesce([{cache: new Cache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: 1, phrase: ''}],{},function(){});
+        coalesce([{cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: 1, phrase: ''}],{},function(){});
     }, /encountered invalid phrase/, 'throws');
 
     assert.end();
 });
 
 (function() {
-    var cache = new Cache('a', 0);
-    cache._set('1', [
+    var memcache = new MemoryCache('a', 0);
+    memcache._set('1', [
         Grid.encode({
             id: 2,
             x: 2,
@@ -258,71 +271,75 @@ test('coalesce args', function(assert) {
             score: 7
         }),
     ]);
-    test('coalesceSingle', function(assert) {
-        coalesce([{
-            cache: cache,
-            mask: 1 << 0,
-            idx: 0,
-            zoom: 2,
-            weight: 1,
-            phrase: '1',
-            prefix: false,
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res[0].relev, 1, '0.relev');
-            assert.deepEqual(res[0][0], { distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '0.0');
-            assert.deepEqual(res[1].relev, 1, '1.relev');
-            assert.deepEqual(res[1][0], { distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 1, tmpid: 3, x: 3, y: 3 }, '1.0');
-            assert.deepEqual(res[2].relev, 0.8, '2.relev');
-            assert.deepEqual(res[2][0], { distance: 0, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 3, tmpid: 2, x: 2, y: 2 }, '2.0');
-            assert.end();
+    var rockscache = toRocksCache(memcache);
+
+    [memcache, rockscache].forEach(function(cache) {
+        test('coalesceSingle: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 1, tmpid: 3, x: 3, y: 3 }, '1.0');
+                assert.deepEqual(res[2].relev, 0.8, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: true, distance: 0, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 3, tmpid: 2, x: 2, y: 2 }, '2.0');
+                assert.end();
+            });
         });
-    });
-    test('coalesceSingle proximity', function(assert) {
-        coalesce([{
-            cache: cache,
-            mask: 1 << 0,
-            idx: 0,
-            zoom: 2,
-            weight: 1,
-            phrase: '1',
-            prefix: false,
-        }], {
-            centerzxy: [3,3,3]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res[0].relev, 1, '0.relev');
-            assert.deepEqual(res[0][0], { distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 112.5, tmpid: 3, x: 3, y: 3 }, '0.0');
-            assert.deepEqual(res[1].relev, 1, '1.relev');
-            assert.deepEqual(res[1][0], { distance: 8, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
-            assert.deepEqual(res[2].relev, 0.8, '2.relev');
-            assert.deepEqual(res[2][0], { distance: 2, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 3, tmpid: 2, x: 2, y: 2 }, '2.0');
-            assert.end();
+        test('coalesceSingle proximity: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {
+                centerzxy: [3,3,3]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 112.5, tmpid: 3, x: 3, y: 3 }, '0.0');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 8, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
+                assert.deepEqual(res[2].relev, 0.8, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: true, distance: 2, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 3, tmpid: 2, x: 2, y: 2 }, '2.0');
+                assert.end();
+            });
         });
-    });
-    test('coalesceSingle bbox', function(assert) {
-        coalesce([{
-            cache: cache,
-            mask: 1 << 0,
-            idx: 0,
-            zoom: 2,
-            weight: 1,
-            phrase: '1',
-            prefix: false,
-        }], {
-            bboxzxy: [2, 1, 1, 1, 1]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res[0].relev, 1, '1.relev');
-            assert.deepEqual(res.length, 1);
-            assert.deepEqual(res[0][0], { distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
-            assert.end();
+        test('coalesceSingle bbox: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {
+                bboxzxy: [2, 1, 1, 1, 1]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res[0].relev, 1, '1.relev');
+                assert.deepEqual(res.length, 1);
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
+                assert.end();
+            });
         });
     });
 })();
 
 (function() {
-    var cache = new Cache('a', 0);
+    var memcache = new MemoryCache('a', 0);
     var grids = [];
     var encoded1 = Grid.encode({
         id: 1,
@@ -340,32 +357,35 @@ test('coalesce args', function(assert) {
         score: 0
     }));
 
-    cache._set('1', grids);
-    test('coalesceSingle', function(assert) {
-        coalesce([{
-            cache: cache,
-            mask: 1 << 0,
-            idx: 0,
-            zoom: 2,
-            weight: 1,
-            phrase: '1',
-            prefix: false,
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            assert.equal(res.length, 2);
-            assert.deepEqual(res[0].relev, 1, '0.relev');
-            assert.deepEqual(res[0][0], { distance: 0, id: 1, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
-            assert.deepEqual(res[1].relev, 1, '1.relev');
-            assert.deepEqual(res[1][0], { distance: 0, id: 2, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
-            assert.end();
+    memcache._set('1', grids);
+    var rockscache = toRocksCache(memcache);
+    [memcache, rockscache].forEach(function(cache) {
+        test('coalesceSingle: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 2);
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 2, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                assert.end();
+            });
         });
     });
 })();
 
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    a._set('1', [
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    memA._set('1', [
         Grid.encode({
             id: 1,
             x: 1,
@@ -381,7 +401,7 @@ test('coalesce args', function(assert) {
             score: 1
         }),
     ]);
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 2,
             x: 2,
@@ -404,72 +424,80 @@ test('coalesce args', function(assert) {
             score: 3
         }),
     ]);
-    test('coalesceUV', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            // sorts by relev, score
-            assert.deepEqual(res[0].relev, 1, '0.relev');
-            assert.deepEqual(res[0][0], { distance: 0, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '0.0');
-            assert.deepEqual(res[0][1], { distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
-            assert.deepEqual(res[1].relev, 1, '1.relev');
-            assert.deepEqual(res[1][0], { distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554435, x: 3, y: 3 }, '1.0');
-            assert.deepEqual(res[1][1], { distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
-            assert.end();
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+
+    [[memA, memB], [rocksA, rocksB], [memA, rocksB]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1];
+
+        test('coalesceUV: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                // sorts by relev, score
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '0.0');
+                assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554435, x: 3, y: 3 }, '1.0');
+                assert.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
+                assert.end();
+            });
         });
-    });
-    test('coalesceUV proximity', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            centerzxy: [2,3,3]
-        }, function(err, res) {
-            assert.ifError(err);
-            // sorts by relev, score
-            assert.deepEqual(res[0].relev, 1, '0.relev');
-            assert.deepEqual(res[0][0], { distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 112.5, tmpid: 33554435, x: 3, y: 3 }, '0.0');
-            assert.deepEqual(res[0][1], { distance: 8, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
-            assert.deepEqual(res[1].relev, 1, '1.relev');
-            assert.deepEqual(res[1][0], { distance: 2, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '1.0');
-            assert.deepEqual(res[1][1], { distance: 8, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
-            assert.end();
+        test('coalesceUV proximity: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                centerzxy: [2,3,3]
+            }, function(err, res) {
+                assert.ifError(err);
+                // sorts by relev, score
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 112.5, tmpid: 33554435, x: 3, y: 3 }, '0.0');
+                assert.deepEqual(res[0][1], { matches_language: true, distance: 8, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 2, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '1.0');
+                assert.deepEqual(res[1][1], { matches_language: true, distance: 8, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
+                assert.end();
+            });
         });
     });
 })();
 
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    a._set('1', [
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    memA._set('1', [
         Grid.encode({
             id: 1,
             x: 0,
@@ -478,7 +506,7 @@ test('coalesce args', function(assert) {
             score: 1
         }),
     ]);
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 2,
             x: 4800,
@@ -494,66 +522,74 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    test('coalesce scoredist (close proximity)', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 0,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 14,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            centerzxy: [14,4601,6200]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res[0][0].id, 3, 'matches feat 3');
-            assert.deepEqual(res[1][0].id, 2, 'matches feat 2');
-            assert.deepEqual(res[0][0].distance < res[1][0].distance, true, 'feat 3 is closer than feat2');
-            assert.end();
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+
+    [[memA, memB], [rocksA, rocksB], [memA, rocksB]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1];
+
+        test('coalesce scoredist (close proximity): ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 0,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 14,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                centerzxy: [14,4601,6200]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res[0][0].id, 3, 'matches feat 3');
+                assert.deepEqual(res[1][0].id, 2, 'matches feat 2');
+                assert.deepEqual(res[0][0].distance < res[1][0].distance, true, 'feat 3 is closer than feat2');
+                assert.end();
+            });
         });
-    });
-    test('coalesce scoredist (far proximity)', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 0,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 14,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            centerzxy: [14,4605,6200]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res[0][0].id, 2, 'matches feat 2 (higher score)');
-            assert.deepEqual(res[1][0].id, 3, 'matches feat 3');
-            assert.deepEqual(res[1][0].distance < res[0][0].distance, true, 'feat 3 is closer than feat2');
-            assert.end();
+        test('coalesce scoredist (far proximity): ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 0,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 14,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                centerzxy: [14,4605,6200]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res[0][0].id, 2, 'matches feat 2 (higher score)');
+                assert.deepEqual(res[1][0].id, 3, 'matches feat 3');
+                assert.deepEqual(res[1][0].distance < res[0][0].distance, true, 'feat 3 is closer than feat2');
+                assert.end();
+            });
         });
     });
 })();
 
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    a._set('1', [
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    memA._set('1', [
         Grid.encode({
             id: 1,
             x: 1,
@@ -569,7 +605,7 @@ test('coalesce args', function(assert) {
             score: 1
         }),
     ]);
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 3,
             x: 2,
@@ -578,32 +614,41 @@ test('coalesce args', function(assert) {
             score: 1
         }),
     ]);
-    test('coalesceMulti (higher relev wins)', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            // sorts by relev, score
-            assert.deepEqual(res.length, 1, '1 result');
-            assert.deepEqual(res[0].relev, 1, '0.relev');
-            assert.deepEqual(res[0].length, 2, '0.length');
-            assert.deepEqual(res[0][0], { distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554435, x: 2, y: 2 }, '0.0');
-            assert.deepEqual(res[0][1], { distance: 0, id: 2, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 2, x: 1, y: 1 }, '0.1');
-            assert.end();
+
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+
+    [[memA, memB], [rocksA, rocksB], [memA, rocksB]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1];
+
+        test('coalesceMulti (higher relev wins): ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                // sorts by relev, score
+                assert.deepEqual(res.length, 1, '1 result');
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0].length, 2, '0.length');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554435, x: 2, y: 2 }, '0.0');
+                assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 2, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 2, x: 1, y: 1 }, '0.1');
+                assert.end();
+            });
         });
     });
 })();
@@ -611,10 +656,10 @@ test('coalesce args', function(assert) {
 
 // cooalese multi bbox
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    var c = new Cache('c', 0);
-    a._set('1', [
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    var memC = new MemoryCache('c', 0);
+    memA._set('1', [
         Grid.encode({
             id: 1,
             x: 0,
@@ -630,7 +675,7 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 3,
             x: 3,
@@ -646,7 +691,7 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    c._set('1', [
+    memC._set('1', [
         Grid.encode({
             id: 5,
             x: 21,
@@ -662,113 +707,124 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    test('coalesceMulti bbox', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            bboxzxy: [1, 0, 0, 1, 0]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res.length, 2, '2 results: 1/0/0, 2/3/0');
-            assert.end();
+
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+    var rocksC = toRocksCache(memC);
+
+    [[memA, memB, memC], [rocksA, rocksB, rocksC], [memA, rocksB, memC]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1],
+            c = caches[2];
+
+        test('coalesceMulti bbox: ' + a.id + ', ' + b.id + ', ' + c.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                bboxzxy: [1, 0, 0, 1, 0]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res.length, 2, '2 results: 1/0/0, 2/3/0');
+                assert.end();
+            });
         });
-    });
-    test('coalesceMulti bbox', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            bboxzxy: [2, 0, 0, 1, 3]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res.length, 2, '2 results: 1/0/0, 2/0/3');
-            assert.end();
+        test('coalesceMulti bbox: ' + a.id + ', ' + b.id + ', ' + c.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                bboxzxy: [2, 0, 0, 1, 3]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res.length, 2, '2 results: 1/0/0, 2/0/3');
+                assert.end();
+            });
         });
-    });
-    test('coalesceMulti bbox', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            bboxzxy: [6, 14, 30, 15, 64]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res.length, 2, '2 results: 1/0/0, 2/0/3');
-            assert.end();
+        test('coalesceMulti bbox: ' + a.id + ', ' + b.id + ', ' + c.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                bboxzxy: [6, 14, 30, 15, 64]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res.length, 2, '2 results: 1/0/0, 2/0/3');
+                assert.end();
+            });
         });
-    });
-    test('coalesceMulti bbox', function(assert) {
-        coalesce([{
-            cache: b,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 2,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: c,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 5,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {
-            bboxzxy: [1, 0, 0, 1, 0]
-        }, function(err, res) {
-            assert.ifError(err);
-            assert.deepEqual(res.length, 2, '2 results: 5/20/7, 2/3/0');
-            assert.end();
+        test('coalesceMulti bbox: ' + a.id + ', ' + b.id + ', ' + c.id, function(assert) {
+            coalesce([{
+                cache: b,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 2,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: c,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 5,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {
+                bboxzxy: [1, 0, 0, 1, 0]
+            }, function(err, res) {
+                assert.ifError(err);
+                assert.deepEqual(res.length, 2, '2 results: 5/20/7, 2/3/0');
+                assert.end();
+            });
         });
     });
 })();
 
 // Multi sandwich scenario
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    a._set('1', [
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    memA._set('1', [
         Grid.encode({
             id: 3,
             x: 0,
@@ -784,7 +840,7 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 1,
             x: 1,
@@ -800,39 +856,47 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    test('coalesceMulti sandwich', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 0,
-            zoom: 0,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 1,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            assert.equal(res.length, 2, 'res length = 2');
-            // sorts by relev, score
-            assert.deepEqual(res[0].map(function(f) { return f.id; }), [1,3], '0.relev = 1');
-            assert.deepEqual(res[1].map(function(f) { return f.id; }), [2,3], '0.relev = 1');
-            assert.end();
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+
+    [[memA, memB], [rocksA, rocksB], [memA, rocksB]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1];
+
+        test('coalesceMulti sandwich: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 0,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 2, 'res length = 2');
+                // sorts by relev, score
+                assert.deepEqual(res[0].map(function(f) { return f.id; }), [1,4], '0.relev = 1');
+                assert.deepEqual(res[1].map(function(f) { return f.id; }), [2,4], '0.relev = 1');
+                assert.end();
+            });
         });
     });
 })();
 
 // Multi sandwich scenario
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    a._set('1', [
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    memA._set('1', [
         Grid.encode({
             id: 3,
             x: 0,
@@ -848,7 +912,7 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 1,
             x: 0,
@@ -857,38 +921,47 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    test('coalesceMulti sandwich', function(assert) {
-        coalesce([{
-            cache: a,
-            mask: 1 << 1,
-            idx: 25,
-            zoom: 0,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 20,
-            zoom: 0,
-            weight: 0.5,
-            phrase: '1',
-            prefix: false,
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            assert.equal(res.length, 2, 'res length = 2');
-            assert.deepEqual(res[0].map(function(f) { return f.id; }), [3,1], '0.relev = 1');
-            assert.deepEqual(res[1].map(function(f) { return f.id; }), [4,1], '0.relev = 1');
-            assert.end();
+
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+
+    [[memA, memB], [rocksA, rocksB], [memA, rocksB]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1];
+
+        test('coalesceMulti sandwich: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 25,
+                zoom: 0,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 20,
+                zoom: 0,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 2, 'res length = 2');
+                assert.deepEqual(res[0].map(function(f) { return f.id; }), [3,1], '0.relev = 1');
+                assert.deepEqual(res[1].map(function(f) { return f.id; }), [4,1], '0.relev = 1');
+                assert.end();
+            });
         });
     });
 })();
 
 // Mask overflow
 (function() {
-    var a = new Cache('a', 0);
-    var b = new Cache('b', 0);
-    var c = new Cache('c', 0);
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    var memC = new MemoryCache('c', 0);
 
     var grids = [];
     for (var i = 1; i < 10e3; i++) grids.push(Grid.encode({
@@ -898,9 +971,9 @@ test('coalesce args', function(assert) {
         relev: 1,
         score: 1
     }));
-    a._set('1', grids);
+    memA._set('1', grids);
 
-    b._set('1', [
+    memB._set('1', [
         Grid.encode({
             id: 1,
             x: 0,
@@ -909,7 +982,7 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
-    c._set('1', [
+    memC._set('1', [
         Grid.encode({
             id: 1,
             x: 0,
@@ -918,72 +991,81 @@ test('coalesce args', function(assert) {
             score: 1
         })
     ]);
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+    var rocksC = toRocksCache(memC);
 
-    test('coalesceMulti mask safe', function(assert) {
-        assert.comment('start coalesce (mask: 2)');
-        coalesce([{
-            cache: a,
-            mask: 1 << 2,
-            idx: 0,
-            zoom: 0,
-            weight: 0.33,
-            phrase: '1',
-            prefix: false
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 0,
-            weight: 0.33,
-            phrase: '1',
-            prefix: false
-        }, {
-            cache: c,
-            mask: 1 << 1,
-            idx: 2,
-            zoom: 0,
-            weight: 0.33,
-            phrase: '1',
-            prefix: false
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            assert.equal(res.length, 1, 'res length = 1');
-            assert.deepEqual(res[0].map(function(f) { return f.id; }), [1, 1, 1], '0.relev = 0.99');
-            assert.end();
+    [[memA, memB, memC], [rocksA, rocksB, rocksC], [memA, rocksB, memC]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1],
+            c = caches[2];
+
+        test('coalesceMulti mask safe: ' + a.id + ', ' + b.id + ', ' + c.id, function(assert) {
+            assert.comment('start coalesce (mask: 2)');
+            coalesce([{
+                cache: a,
+                mask: 1 << 2,
+                idx: 0,
+                zoom: 0,
+                weight: 0.33,
+                phrase: '1',
+                prefix: false
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 0,
+                weight: 0.33,
+                phrase: '1',
+                prefix: false
+            }, {
+                cache: c,
+                mask: 1 << 1,
+                idx: 2,
+                zoom: 0,
+                weight: 0.33,
+                phrase: '1',
+                prefix: false
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 1, 'res length = 1');
+                assert.deepEqual(res[0].map(function(f) { return f.id; }), [1, 9999, 1], '0.relev = 0.99');
+                assert.end();
+            });
         });
-    });
 
-    test('coalesceMulti mask overflow', function(assert) {
-        assert.comment('start coalesce (mask: 18)');
-        coalesce([{
-            cache: a,
-            mask: 1 << 18,
-            idx: 0,
-            zoom: 0,
-            weight: 0.33,
-            phrase: '1',
-            prefix: false
-        }, {
-            cache: b,
-            mask: 1 << 0,
-            idx: 1,
-            zoom: 0,
-            weight: 0.33,
-            phrase: '1',
-            prefix: false
-        }, {
-            cache: c,
-            mask: 1 << 1,
-            idx: 2,
-            zoom: 0,
-            weight: 0.33,
-            phrase: '1',
-            prefix: false
-        }], {}, function(err, res) {
-            assert.ifError(err);
-            assert.equal(res.length, 1, 'res length = 1');
-            assert.deepEqual(res[0].map(function(f) { return f.id; }), [1, 1, 1], '0.relev = 0.99');
-            assert.end();
+        test('coalesceMulti mask overflow: ' + a.id + ', ' + b.id + ', ' + c.id, function(assert) {
+            assert.comment('start coalesce (mask: 18)');
+            coalesce([{
+                cache: a,
+                mask: 1 << 18,
+                idx: 0,
+                zoom: 0,
+                weight: 0.33,
+                phrase: '1',
+                prefix: false
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 0,
+                weight: 0.33,
+                phrase: '1',
+                prefix: false
+            }, {
+                cache: c,
+                mask: 1 << 1,
+                idx: 2,
+                zoom: 0,
+                weight: 0.33,
+                phrase: '1',
+                prefix: false
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 1, 'res length = 1');
+                assert.deepEqual(res[0].map(function(f) { return f.id; }), [1, 9999, 1], '0.relev = 0.99');
+                assert.end();
+            });
         });
     });
 })();

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -383,6 +383,112 @@ test('coalesce args', function(assert) {
 })();
 
 (function() {
+    var memcache = new MemoryCache('a', 0);
+    var grids = [];
+
+    memcache._set('1', [Grid.encode({
+        id: 1,
+        x: 1,
+        y: 1,
+        relev: 1,
+        score: 0
+    })], [0]);
+    memcache._set('1', [Grid.encode({
+        id: 2,
+        x: 1,
+        y: 1,
+        relev: 1,
+        score: 0
+    })], [1]);
+    memcache._set('1', [Grid.encode({
+        id: 3,
+        x: 1,
+        y: 1,
+        relev: 1,
+        score: 0
+    })], [0,1]);
+    memcache._set('1', [Grid.encode({
+        id: 4,
+        x: 1,
+        y: 1,
+        relev: 1,
+        score: 0
+    })], [2]);
+    var rockscache = toRocksCache(memcache);
+    [memcache, rockscache].forEach(function(cache) {
+        test('coalesceSingle, ALL_LANGUAGES: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 4);
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 2, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[2].relev, 1, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[3].relev, 1, '3.relev');
+                assert.deepEqual(res[3][0], { matches_language: true, distance: 0, id: 4, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                assert.end();
+            });
+        });
+        test('coalesceSingle, [0]: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {languages: [0]}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 4);
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[2].relev, 0.8, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[3].relev, 0.8, '3.relev');
+                assert.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                assert.end();
+            });
+        });
+        test('coalesceSingle, [3]: ' + cache.id, function(assert) {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: false,
+            }], {languages: [3]}, function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.length, 4);
+                assert.deepEqual(res[0].relev, 0.8, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 1, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[1].relev, 0.8, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[2].relev, 0.8, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 3, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[3].relev, 0.8, '3.relev');
+                assert.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                assert.end();
+            });
+        });
+    });
+})();
+
+(function() {
     var memA = new MemoryCache('a', 0);
     var memB = new MemoryCache('b', 0);
     memA._set('1', [
@@ -488,6 +594,135 @@ test('coalesce args', function(assert) {
                 assert.deepEqual(res[1].relev, 1, '1.relev');
                 assert.deepEqual(res[1][0], { matches_language: true, distance: 2, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '1.0');
                 assert.deepEqual(res[1][1], { matches_language: true, distance: 8, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
+                assert.end();
+            });
+        });
+    });
+})();
+
+(function() {
+    var memA = new MemoryCache('a', 0);
+    var memB = new MemoryCache('b', 0);
+    memA._set('1', [
+        Grid.encode({
+            id: 1,
+            x: 1,
+            y: 1,
+            relev: 1,
+            score: 1
+        })
+    ]);
+    memB._set('1', [
+        Grid.encode({
+            id: 2,
+            x: 1,
+            y: 1,
+            relev: 1,
+            score: 1
+        })
+    ], [0]);
+    memB._set('1', [
+        Grid.encode({
+            id: 3,
+            x: 1,
+            y: 1,
+            relev: 1,
+            score: 1
+        })
+    ], [1]);
+    var rocksA = toRocksCache(memA);
+    var rocksB = toRocksCache(memB);
+
+    [[memA, memB], [rocksA, rocksB], [memA, rocksB]].forEach(function(caches) {
+        var a = caches[0],
+            b = caches[1];
+
+        test('coalesceMulti, ALL_LANGUAGES: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {}, function(err, res) {
+                assert.ifError(err);
+                // sorts by relev, score
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
+                assert.deepEqual(res[1].relev, 1, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                assert.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
+                assert.end();
+            });
+        });
+        test('coalesceMulti, [0]: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {languages: [0]}, function(err, res) {
+                assert.ifError(err);
+                // sorts by relev, score
+                assert.deepEqual(res[0].relev, 1, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
+                // one of our indexes has languages and the other does not, so relev will be 0.9 because it's (.5 + .8*.5)
+                assert.deepEqual(res[1].relev, 0.9, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.4, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                assert.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
+                assert.end();
+            });
+        });
+        test('coalesceMulti, [3]: ' + a.id + ', ' + b.id, function(assert) {
+            coalesce([{
+                cache: a,
+                mask: 1 << 1,
+                idx: 0,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }, {
+                cache: b,
+                mask: 1 << 0,
+                idx: 1,
+                zoom: 1,
+                weight: 0.5,
+                phrase: '1',
+                prefix: false,
+            }], {languages: [3]}, function(err, res) {
+                assert.ifError(err);
+                // sorts by relev, score
+                assert.deepEqual(res[0].relev, 0.9, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 2, idx: 1, relev: 0.4, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
+                // one of our indexes has languages and the other does not, so relev will be 0.9 because it's (.5 + .8*.5)
+                assert.deepEqual(res[1].relev, 0.9, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.4, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                assert.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
                 assert.end();
             });
         });

--- a/test/langfield.fuzz.test.js
+++ b/test/langfield.fuzz.test.js
@@ -1,0 +1,57 @@
+var carmenCache = require('../index.js');
+var tape = require('tape');
+var fs = require('fs');
+var mp53 = Math.pow(2,53);
+
+var tmpdir = "/tmp/temp." + Math.random().toString(36).substr(2, 5);
+fs.mkdirSync(tmpdir);
+var tmpidx = 0;
+var tmpfile = function() { return tmpdir + "/" + (tmpidx++) + ".dat"; };
+
+tape('language fuzzing', function(assert) {
+    var cache = new carmenCache.MemoryCache('a');
+
+    var records = new Map();
+    for (var j = 0; j < 1000; j++) {
+        var phrase = Math.random().toString(36).substr(2, 3 + Math.floor(Math.random() * 6));
+        var numLanguages = Math.floor(Math.random() * 4);
+        var languages;
+        if (numLanguages == 0) {
+            languages = null;
+        } else {
+            languages = new Set();
+            for (var i = 0; i < numLanguages; i++) {
+                languages.add(Math.floor(Math.random() * 128));
+            }
+            languages = Array.from(languages).sort(function(a, b) { return a - b; });
+        }
+        var recordId = phrase + "-" + (languages == null ? "null" : languages.join("-"));
+        records.set(recordId, {phrase: phrase, languages: languages});
+
+        cache._set(phrase, [1], languages);
+    }
+
+    var list = cache.list();
+    assert.equal(list.length, records.size, "got the same number of items out as went in");
+    var hasAll = true;
+    for (var item of list) {
+        var recordId = item[0] + "-" + (item[1] == null ? "null" : item[1].join("-"));
+        hasAll = hasAll && records.has(recordId);
+    }
+    assert.ok(hasAll, "all records and languages came out that went in");
+
+    var pack = tmpfile();
+    cache.pack(pack);
+    var loader = new carmenCache.RocksDBCache('b', pack);
+
+    list = loader.list();
+    assert.equal(list.length, records.size, "got the same number of items out as went in");
+    var hasAll = true;
+    for (var item of list) {
+        var recordId = item[0] + "-" + (item[1] == null ? "null" : item[1].join("-"));
+        hasAll = hasAll && records.has(recordId);
+    }
+    assert.ok(hasAll, "all records and languages came out that went in");
+
+    assert.end();
+});

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -1,0 +1,185 @@
+var carmenCache = require('../index.js');
+var tape = require('tape');
+var fs = require('fs');
+var mp53 = Math.pow(2,53);
+var Grid = require('./grid.js');
+
+var tmpdir = "/tmp/temp." + Math.random().toString(36).substr(2, 5);
+fs.mkdirSync(tmpdir);
+var tmpidx = 0;
+var tmpfile = function() { return tmpdir + "/" + (tmpidx++) + ".dat"; };
+
+var getIds = function(grids) {
+    return grids.map(function(x) { return x.id; }).sort(function (a, b) { return a - b; });
+}
+
+var getByLanguageMatch = function(grids, match) {
+    return grids.filter(function(x) { return x.matches_language == match; });
+}
+
+tape('getMatching', function(assert) {
+    var cache = new carmenCache.MemoryCache('mem');
+
+    cache._set('test', [
+        Grid.encode({id: 1, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 2, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 3, x: 1, y: 1, relev: 1, score: 1})
+    ]);
+    cache._set('test', [
+        Grid.encode({id: 11, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 12, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 13, x: 1, y: 1, relev: 1, score: 1})
+    ], [0]);
+    cache._set('test', [
+        Grid.encode({id: 21, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 22, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 23, x: 1, y: 1, relev: 1, score: 1})
+    ], [1]);
+    cache._set('test', [
+        Grid.encode({id: 31, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 32, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 33, x: 1, y: 1, relev: 1, score: 1})
+    ], [1,2]);
+    cache._set('test', [
+        Grid.encode({id: 41, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 42, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 43, x: 1, y: 1, relev: 1, score: 1})
+    ], [3,4]);
+
+    cache._set('testy', [
+        Grid.encode({id: 51, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 52, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 53, x: 1, y: 1, relev: 1, score: 1})
+    ], [0]);
+    cache._set('tentacle', [
+        Grid.encode({id: 61, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 62, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 63, x: 1, y: 1, relev: 1, score: 1})
+    ], [0]);
+
+    cache._set('hello', [
+        Grid.encode({id: 71, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 72, x: 1, y: 1, relev: 1, score: 1}),
+        Grid.encode({id: 73, x: 1, y: 1, relev: 1, score: 1})
+    ], [0]);
+
+    // cache A serializes data, cache B loads serialized data.
+    var pack = tmpfile();
+    cache.pack(pack);
+    var loader = new carmenCache.RocksDBCache('packed', pack);
+
+    [cache, loader].forEach(function(c) {
+        var test_all_langs_no_prefix = cache._getMatching("test", false);
+        assert.deepEqual(
+            getIds(test_all_langs_no_prefix),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43],
+            "getMatching for 'test' with no prefix match and no language includes all IDs for 'test'"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_no_prefix),
+            getIds(getByLanguageMatch(test_all_langs_no_prefix, true)),
+            "getMatching for 'test' with no prefix match and no language includes only match_language: true"
+        );
+
+        var test_all_langs_with_prefix = cache._getMatching("test", true);
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
+            "getMatching for 'test' with prefix match and no language includes all IDs for 'test' and 'testy'"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix),
+            getIds(getByLanguageMatch(test_all_langs_with_prefix, true)),
+            "getMatching for 'test' with prefix match and no language includes only match_language: true"
+        );
+
+        assert.false(cache._getMatching("te", false), "getMatching for 'te' with no prefix match returns nothing");
+
+        var te_all_langs_with_prefix = cache._getMatching("te", true);
+        assert.deepEqual(
+            getIds(te_all_langs_with_prefix),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53, 61, 62, 63],
+            "getMatching for 'te' with prefix match and no language includes all IDs for 'test' and 'testy' and 'tentacle'"
+        );
+        assert.deepEqual(
+            getIds(te_all_langs_with_prefix),
+            getIds(getByLanguageMatch(te_all_langs_with_prefix, true)),
+            "getMatching for 'te' with prefix match and no language includes only match_language: true"
+        );
+
+        var test_all_langs_with_prefix_0 = cache._getMatching("test", true, [0]);
+        var test_all_langs_with_prefix_0_matched = getByLanguageMatch(test_all_langs_with_prefix_0, true);
+        var test_all_langs_with_prefix_0_unmatched = getByLanguageMatch(test_all_langs_with_prefix_0, false);
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_0),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
+            "getMatching for 'test' with prefix match and language [0] includes all IDs for 'test' and 'testy'"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_0_matched),
+            [1, 2, 3, 11, 12, 13, 51, 52, 53],
+            "getMatching for 'test' with prefix match and language [0] includes language_match: true for IDs for 'test' and 'testy' with language 0"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_0_unmatched),
+            [21, 22, 23, 31, 32, 33, 41, 42, 43],
+            "getMatching for 'test' with prefix match and language [0] includes language_match: false for IDs for 'test' and 'testy' without language 0"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_0.slice(0, test_all_langs_with_prefix_0_matched.length)),
+            getIds(test_all_langs_with_prefix_0_matched),
+            "all the language-matching results come first"
+        );
+
+        var test_all_langs_with_prefix_1 = cache._getMatching("test", true, [1]);
+        var test_all_langs_with_prefix_1_matched = getByLanguageMatch(test_all_langs_with_prefix_1, true);
+        var test_all_langs_with_prefix_1_unmatched = getByLanguageMatch(test_all_langs_with_prefix_1, false);
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_1),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
+            "getMatching for 'test' with prefix match and language [1] includes all IDs for 'test' and 'testy'"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_1_matched),
+            [1, 2, 3, 21, 22, 23, 31, 32, 33],
+            "getMatching for 'test' with prefix match and language [1] includes language_match: true for IDs for 'test' and 'testy' for both language 1 and language 0,1"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_1_unmatched),
+            [11, 12, 13, 41, 42, 43, 51, 52, 53],
+            "getMatching for 'test' with prefix match and language [1] includes language_match: false for IDs for 'test' and 'testy' without language 1"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_1.slice(0, test_all_langs_with_prefix_1_matched.length)),
+            getIds(test_all_langs_with_prefix_1_matched),
+            "all the language-matching results come first"
+        );
+
+        var test_all_langs_with_prefix_7 = cache._getMatching("test", true, [7]);
+        var test_all_langs_with_prefix_7_matched = getByLanguageMatch(test_all_langs_with_prefix_7, true);
+        var test_all_langs_with_prefix_7_unmatched = getByLanguageMatch(test_all_langs_with_prefix_7, false);
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_7),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
+            "getMatching for 'test' with prefix match and language [7] includes all IDs for 'test' and 'testy'"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_7_matched),
+            [1, 2, 3],
+            "getMatching for 'test' with prefix match and language [7] includes only language_match: true for IDs for 'test' and 'testy' with no language set"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_7_unmatched),
+            [11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
+            "getMatching for 'test' with prefix match and language [7] includes language_match: false for all IDs for 'test' and 'testy' with a language set"
+        );
+        assert.deepEqual(
+            getIds(test_all_langs_with_prefix_7.slice(0, test_all_langs_with_prefix_7_matched.length)),
+            getIds(test_all_langs_with_prefix_7_matched),
+            "all the language-matching results come first"
+        );
+    });
+
+    // assert.deepEqual(loader.list('grid'), [ 'else.', 'something', 'test', 'test.' ], 'keys in shard');
+    assert.end();
+});

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -131,6 +131,30 @@ tape('getMatching', function(assert) {
             "all the language-matching results come first"
         );
 
+        var te_all_langs_with_prefix_0 = cache._getMatching("te", true, [0]);
+        var te_all_langs_with_prefix_0_matched = getByLanguageMatch(te_all_langs_with_prefix_0, true);
+        var te_all_langs_with_prefix_0_unmatched = getByLanguageMatch(te_all_langs_with_prefix_0, false);
+        assert.deepEqual(
+            getIds(te_all_langs_with_prefix_0),
+            [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53, 61, 62, 63],
+            "getMatching for 'te' with prefix match and language [0] includes all IDs for 'tentacle' and 'test' and 'testy'"
+        );
+        assert.deepEqual(
+            getIds(te_all_langs_with_prefix_0_matched),
+            [1, 2, 3, 11, 12, 13, 51, 52, 53, 61, 62, 63],
+            "getMatching for 'te' with prefix match and language [0] includes language_match: true for IDs for 'tentacle' and 'test' and 'testy' with language 0"
+        );
+        assert.deepEqual(
+            getIds(te_all_langs_with_prefix_0_unmatched),
+            [21, 22, 23, 31, 32, 33, 41, 42, 43],
+            "getMatching for 'te' with prefix match and language [0] includes language_match: false for IDs for 'tentacle' and 'test' and 'testy' without language 0"
+        );
+        assert.deepEqual(
+            getIds(te_all_langs_with_prefix_0.slice(0, te_all_langs_with_prefix_0_matched.length)),
+            getIds(te_all_langs_with_prefix_0_matched),
+            "all the language-matching results come first"
+        );
+
         var test_all_langs_with_prefix_1 = cache._getMatching("test", true, [1]);
         var test_all_langs_with_prefix_1_matched = getByLanguageMatch(test_all_langs_with_prefix_1, true);
         var test_all_langs_with_prefix_1_unmatched = getByLanguageMatch(test_all_langs_with_prefix_1, false);


### PR DESCRIPTION
This is an implementation of the final multilingual grid proposal described [here](https://github.com/mapbox/carmen/issues/547). Grid keys are now annotated with a bitfield describing the languages to which the given combination of key and grids applies.

A bit of extra detail beyond the carmen PR (but read the carmen PR too)...

About the key format:
* this PR introduces an internal language field type, which is currently typedef'ed to an unsigned 128-bit int (using the nonstandard `__int128` clang intrinsic). The index format does not depend on these fields being 128-bit, however, as the language suffix is variably sized.
* keys are formatted as `key|langfield` (with an actual pipe character as the separator), and the langfield is a variable-width bit field that's copied into the least significant bytes of a 128-bit int at read time. The field will thus only be as many bytes as is necessary to represent the highest-bit-number language present for the field.
* as an additional space optimization, the langfield can be omitted entirely (such that the key just ends with a `|` character). This is interpreted as if the field had been `ALL_LANGUAGES` (which is an all-true bit field). So the read algorithm is: find the index of the first `|` character in the key, check if it's the last character in the key, and if so, return `ALL_LANGUAGES`; if not, copy the bytes of the field into the least significant bytes (first bytes as we're on a little-endian architecture) of a new `__int128` and return it.

About other algorithmic stuff:
* `getByPrefix` has been replaced by a new `getMatching` which both checks prefixes and languages. In the event of a language match failure, one of the unused grid bits (as we only use 53 for JS number reasons) is used to track language-matching, which causes all language-matches to sort higher than all non-language-matches in the priority queue.
* In coalesce, that bit is checked, and we additionally apply a 20% relevance penalty in the event of a language match failure.