### PR TITLE
Ensure Context is noncopyable

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1416,7 +1416,7 @@ void coalesceSingle(uv_work_t* req) {
         // sort grids by distance to proximity point
         // TODO: partial_sort here would be ideal
         std::sort(covers.begin(), covers.end(), coverSortByRelev);
-        std::size_t max_contexts = std::min(num_covers,static_cast<std::size_t>(80));
+        std::size_t max_contexts = std::min(covers.size(),static_cast<std::size_t>(40));
 
         uint32_t lastid = 0;
         std::size_t added = 0;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -24,14 +24,14 @@ Nan::Persistent<FunctionTemplate> RocksDBCache::constructor;
 rocksdb::Status OpenDB(const rocksdb::Options& options, const std::string& name, std::unique_ptr<rocksdb::DB>& dbptr) {
     rocksdb::DB* db;
     rocksdb::Status status = rocksdb::DB::Open(options, name, &db);
-    dbptr = std::move(std::unique_ptr<rocksdb::DB>(db));
+    dbptr = std::unique_ptr<rocksdb::DB>(db);
     return status;
 }
 
 rocksdb::Status OpenForReadOnlyDB(const rocksdb::Options& options, const std::string& name, std::unique_ptr<rocksdb::DB>& dbptr) {
     rocksdb::DB* db;
     rocksdb::Status status = rocksdb::DB::OpenForReadOnly(options, name, &db);
-    dbptr = std::move(std::unique_ptr<rocksdb::DB>(db));
+    dbptr = std::unique_ptr<rocksdb::DB>(db);
     return status;
 }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1093,7 +1093,8 @@ struct Context {
     uint32_t mask;
     double relev;
 
-    Context(Context const& c) = default;
+    Context(Context const& c) = delete;
+    Context& operator=(Context const& c) = delete;
     Context(Cover && cov,
             uint32_t mask,
             double relev)

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1093,6 +1093,7 @@ struct Context {
     uint32_t mask;
     double relev;
 
+    Context() = delete;
     Context(Context const& c) = delete;
     Context& operator=(Context const& c) = delete;
     Context(Cover && cov,
@@ -1294,12 +1295,12 @@ double scoredist(unsigned zoom, double distance, double score) {
 
 void coalesceFinalize(CoalesceBaton* baton, std::vector<Context> && contexts) {
     if (!contexts.empty()) {
+        std::size_t max_contexts = std::min(contexts.size(),static_cast<std::size_t>(40));
         // Coalesce stack, generate relevs.
         double relevMax = contexts[0].relev;
         std::size_t total = 0;
         std::map<uint64_t,bool> sets;
         std::map<uint64_t,bool>::iterator sit;
-        std::size_t max_contexts = std::min(contexts.size(),static_cast<std::size_t>(40));
         baton->features.reserve(max_contexts);
         for (auto && context : contexts) {
             // Maximum allowance of coalesced features: 40.
@@ -1413,12 +1414,13 @@ void coalesceSingle(uv_work_t* req) {
         }
 
         // sort grids by distance to proximity point
-        std::sort(covers.begin(), covers.end(), coverSortByRelev);
+        std::size_t num_covers = covers.size();
+        std::size_t max_contexts = std::min(num_covers,static_cast<std::size_t>(80));
+        std::partial_sort(covers.begin(), covers.begin()+max_contexts, covers.end(), coverSortByRelev);
 
         uint32_t lastid = 0;
         std::size_t added = 0;
         std::vector<Context> contexts;
-        std::size_t max_contexts = std::min(covers.size(),static_cast<std::size_t>(40));
         contexts.reserve(max_contexts);
         for (auto && cover : covers) {
             // Stop at 40 contexts
@@ -1624,8 +1626,10 @@ void coalesceMulti(uv_work_t* req) {
                 contexts.emplace_back(std::move(context));
             }
         }
+        std::size_t num_contexts = contexts.size();
+        std::size_t max_contexts = std::min(num_contexts,static_cast<std::size_t>(150));
+        std::partial_sort(contexts.begin(), contexts.begin()+max_contexts, contexts.end(), contextSortByRelev);
 
-        std::sort(contexts.begin(), contexts.end(), contextSortByRelev);
         coalesceFinalize(baton, std::move(contexts));
     } catch (std::exception const& ex) {
        baton->error = ex.what();

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1414,9 +1414,9 @@ void coalesceSingle(uv_work_t* req) {
         }
 
         // sort grids by distance to proximity point
-        std::size_t num_covers = covers.size();
+        // TODO: partial_sort here would be ideal
+        std::sort(covers.begin(), covers.end(), coverSortByRelev);
         std::size_t max_contexts = std::min(num_covers,static_cast<std::size_t>(80));
-        std::partial_sort(covers.begin(), covers.begin()+max_contexts, covers.end(), coverSortByRelev);
 
         uint32_t lastid = 0;
         std::size_t added = 0;
@@ -1626,10 +1626,8 @@ void coalesceMulti(uv_work_t* req) {
                 contexts.emplace_back(std::move(context));
             }
         }
-        std::size_t num_contexts = contexts.size();
-        std::size_t max_contexts = std::min(num_contexts,static_cast<std::size_t>(150));
-        std::partial_sort(contexts.begin(), contexts.begin()+max_contexts, contexts.end(), contextSortByRelev);
-
+        // TODO: partial_sort here would be ideal
+        std::sort(contexts.begin(), contexts.end(), contextSortByRelev);
         coalesceFinalize(baton, std::move(contexts));
     } catch (std::exception const& ex) {
        baton->error = ex.what();

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1418,7 +1418,7 @@ void coalesceSingle(uv_work_t* req) {
         uint32_t lastid = 0;
         std::size_t added = 0;
         std::vector<Context> contexts;
-        std::size_t max_contexts = 40;
+        std::size_t max_contexts = std::min(covers.size(),static_cast<std::size_t>(40));
         contexts.reserve(max_contexts);
         for (auto && cover : covers) {
             // Stop at 40 contexts

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1299,7 +1299,7 @@ void coalesceFinalize(CoalesceBaton* baton, std::vector<Context> && contexts) {
         std::size_t total = 0;
         std::map<uint64_t,bool> sets;
         std::map<uint64_t,bool>::iterator sit;
-        std::size_t max_contexts = 40;
+        std::size_t max_contexts = std::min(contexts.size(),static_cast<std::size_t>(40));
         baton->features.reserve(max_contexts);
         for (auto && context : contexts) {
             // Maximum allowance of coalesced features: 40.


### PR DESCRIPTION
This fixes an odd case (still need to research more into the why here) where Context objects were still being copied rather than moved (even though they had a move constructor enabled).

By moving these large objects we should avoid many allocations and help speed up performance. 

On OS X this leads to a significant speedup. On Linux the speedup is less but still noticable.

OSX shows:

#### Master

```
# coalesceMulti
ok 117 coalesceMulti @ 7.56ms
# coalesceMulti proximity
ok 118 coalesceMulti + proximity @ 7.44ms
```

#### This branch

```
ok 117 coalesceMulti @ 6.62ms
# coalesceMulti proximity
ok 118 coalesceMulti + proximity @ 6.46ms
```