### PR TITLE
Make penalty for non-matching language matches gentler

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1382,7 +1382,7 @@ void coalesceSingle(uv_work_t* req) {
             cover.idx = subq.idx;
             cover.tmpid = static_cast<uint32_t>(cover.idx * POW2_25 + cover.id);
             cover.relev = cover.relev * subq.weight;
-            if (!cover.matches_language) cover.relev *= .8;
+            if (!cover.matches_language) cover.relev *= .9;
             cover.distance = proximity ? tileDist(cx, cy, cover.x, cover.y) : 0;
             cover.scoredist = proximity ? scoredist(cz, cover.distance, cover.score) : cover.score;
 
@@ -1532,7 +1532,7 @@ void coalesceMulti(uv_work_t* req) {
                 cover.mask = subq.mask;
                 cover.tmpid = static_cast<uint32_t>(cover.idx * POW2_25 + cover.id);
                 cover.relev = cover.relev * subq.weight;
-                if (!cover.matches_language) cover.relev *= .8;
+                if (!cover.matches_language) cover.relev *= .9;
                 if (proximity) {
                     ZXY dxy = pxy2zxy(z, cover.x, cover.y, cz);
                     cover.distance = tileDist(cx, cy, dxy.x, dxy.y);

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -456,10 +456,10 @@ test('coalesce args', function(assert) {
                 assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
                 assert.deepEqual(res[1].relev, 1, '1.relev');
                 assert.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
-                assert.deepEqual(res[2].relev, 0.8, '2.relev');
-                assert.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
-                assert.deepEqual(res[3].relev, 0.8, '3.relev');
-                assert.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[2].relev, 0.9, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[3].relev, 0.9, '3.relev');
+                assert.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
                 assert.end();
             });
         });
@@ -476,14 +476,14 @@ test('coalesce args', function(assert) {
             }], {}, function(err, res) {
                 assert.ifError(err);
                 assert.equal(res.length, 4);
-                assert.deepEqual(res[0].relev, 0.8, '0.relev');
-                assert.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 1, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
-                assert.deepEqual(res[1].relev, 0.8, '1.relev');
-                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
-                assert.deepEqual(res[2].relev, 0.8, '2.relev');
-                assert.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 3, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
-                assert.deepEqual(res[3].relev, 0.8, '3.relev');
-                assert.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.8, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[0].relev, 0.9, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 1, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[1].relev, 0.9, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[2].relev, 0.9, '2.relev');
+                assert.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 3, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[3].relev, 0.9, '3.relev');
+                assert.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
                 assert.end();
             });
         });
@@ -692,9 +692,9 @@ test('coalesce args', function(assert) {
                 assert.deepEqual(res[0].relev, 1, '0.relev');
                 assert.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
                 assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
-                // one of our indexes has languages and the other does not, so relev will be 0.9 because it's (.5 + .8*.5)
-                assert.deepEqual(res[1].relev, 0.9, '1.relev');
-                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.4, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                // one of our indexes has languages and the other does not, so relev will be 0.95 because it's (.5 + .9*.5)
+                assert.deepEqual(res[1].relev, 0.95, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.45, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
                 assert.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
                 assert.end();
             });
@@ -720,12 +720,12 @@ test('coalesce args', function(assert) {
             }], {}, function(err, res) {
                 assert.ifError(err);
                 // sorts by relev, score
-                assert.deepEqual(res[0].relev, 0.9, '0.relev');
-                assert.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 2, idx: 1, relev: 0.4, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
+                assert.deepEqual(res[0].relev, 0.95, '0.relev');
+                assert.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 2, idx: 1, relev: 0.45, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
                 assert.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
                 // one of our indexes has languages and the other does not, so relev will be 0.9 because it's (.5 + .8*.5)
-                assert.deepEqual(res[1].relev, 0.9, '1.relev');
-                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.4, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                assert.deepEqual(res[1].relev, 0.95, '1.relev');
+                assert.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.45, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
                 assert.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
                 assert.end();
             });


### PR DESCRIPTION
- Adjusts `* 0.8` penalty to be `* 0.9`

Context: with the adjustments in https://github.com/mapbox/carmen/pull/645, previous data that primarily relied on default text to get "full" language match results will no longer. That makes a much larger swath of possible results get this penalty.

To make this change gentler on API consumer using `relev` to set thresholds, this makes the the penalty applied much gentler.

cc @mapbox/geocoding-gang 