### PR TITLE
Normalizer cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.18.5",
+  "version": "0.18.5-normalizer",
   "dependencies": {
     "node-pre-gyp": "~0.6.32",
     "nan": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.18.3",
+  "version": "0.18.4",
   "dependencies": {
     "node-pre-gyp": "~0.6.32",
     "nan": "~2.5.1",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -2200,7 +2200,7 @@ NAN_METHOD(NormalizationCache::getprefixrange) {
         if (key >= ceiling) break;
 
         uint32_t val = *reinterpret_cast<const uint32_t*>(rit->value().ToString().data());
-        if (val < start_id || start_id >= ceiling) {
+        if (val < start_id || val >= ceiling) {
             out->Set(out_idx++,Nan::New(val));
 
             return_count++;

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -31,6 +31,8 @@
 #include <cstring>
 
 #include "rocksdb/db.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/write_batch.h"
 
 namespace carmen {
 
@@ -83,6 +85,22 @@ public:
     static NAN_METHOD(_set);
     static NAN_METHOD(coalesce);
     explicit RocksDBCache();
+    void _ref() { Ref(); }
+    void _unref() { Unref(); }
+    std::shared_ptr<rocksdb::DB> db;
+};
+
+class NormalizationCache: public node::ObjectWrap {
+public:
+    ~NormalizationCache();
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static void Initialize(v8::Handle<v8::Object> target);
+    static NAN_METHOD(New);
+    static NAN_METHOD(get);
+    static NAN_METHOD(getprefixrange);
+    static NAN_METHOD(getall);
+    static NAN_METHOD(writebatch);
+    explicit NormalizationCache();
     void _ref() { Ref(); }
     void _unref() { Unref(); }
     std::shared_ptr<rocksdb::DB> db;

--- a/test/coalesce.bench.test.js
+++ b/test/coalesce.bench.test.js
@@ -5,6 +5,9 @@ var test = require('tape');
 var mp36 = Math.pow(2,36);
 
 (function() {
+    // asan makes everything slow, so skip benching
+    if (process.env.ASAN_OPTIONS) return;
+
     var runs = 50;
     var b = new Cache('b');
     b._set('3848571113', require('./fixtures/coalesce-bench-single-3848571113.json'));
@@ -77,6 +80,9 @@ var mp36 = Math.pow(2,36);
 })();
 
 (function() {
+    // asan makes everything slow, so skip benching
+    if (process.env.ASAN_OPTIONS) return;
+
     var runs = 50;
     var a = new Cache('a', 0);
     var b = new Cache('b', 0);

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -1,0 +1,64 @@
+var carmenCache = require('../index.js');
+var tape = require('tape');
+var fs = require('fs');
+
+var tmpdir = "/tmp/temp." + Math.random().toString(36).substr(2, 5);
+fs.mkdirSync(tmpdir);
+var tmpidx = 0;
+var tmpfile = function() { return tmpdir + "/" + (tmpidx++) + ".dat"; };
+
+var sorted = function(arr) {
+    return [].concat(arr).sort();
+}
+
+var sortedDescending = function(arr) {
+    return [].concat(arr).sort(function (a, b) { return b - a; });
+}
+
+var words = [
+    "first street",
+    "1st st",
+    "frank blvd",
+    "frank boulevard",
+    "fred road",
+    "apple lane",
+    "pear avenue",
+    "pear ave",
+].sort();
+
+var norm = {
+    'first street': '1st st',
+    'frank boulevard': 'frank blvd',
+    'pear avenue': 'pear ave'
+}
+
+var file = tmpfile();
+
+tape('write/dump', function(assert) {
+    var cache = new carmenCache.NormalizationCache(file, false);
+
+    var map = [];
+    for (var key in norm) {
+        map.push([words.indexOf(key), words.indexOf(norm[key])])
+    }
+    cache.writeBatch(map);
+
+    assert.deepEqual(map, cache.getAll(), "dumped contents match input");
+
+    return assert.end();
+});
+
+tape('read', function(assert) {
+    var cache = new carmenCache.NormalizationCache(file, true);
+
+    assert.equal(cache.get(words.indexOf('first street')), words.indexOf('1st st'));
+
+    // find the indexes of all the keys that start with f
+    var f = [];
+    for (let i = 0; i < words.length; i++) if (words[i].charAt(0) == 'f') f.push(i);
+    assert.deepEqual(cache.getPrefixRange(f[0], f.length), [words.indexOf('1st st')], 'found normalization for 1st st but not frank boulevard');
+
+    assert.deepEqual(cache.getPrefixRange(words.indexOf('frank boulevard'), 1), [words.indexOf('frank blvd')], 'found frank boulevard because no prefixes are shared');
+
+    assert.end();
+});

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -41,6 +41,24 @@ tape('write/dump', function(assert) {
     for (var key in norm) {
         map.push([words.indexOf(key), words.indexOf(norm[key])])
     }
+
+    // These tests just illustrate what the mapping actually is storing.
+    // Note the mapping is based on index position of sorted text based
+    // on how dawg-cache stores.
+    assert.deepEqual(words, [
+        "1st st",
+        "apple lane",
+        "first street",
+        "frank blvd",
+        "frank boulevard",
+        "fred road",
+        "pear ave",
+        "pear avenue"
+    ], "confirm map sorted order simulating dawg text order");
+    assert.deepEqual(map[0], [ 2, 0 ], 'first street => 1st st');
+    assert.deepEqual(map[1], [ 4, 3 ], 'frank boulevard => frank blvd');
+    assert.deepEqual(map[2], [ 7, 6 ], 'pear avenue => pear ave');
+
     cache.writeBatch(map);
 
     assert.deepEqual(map, cache.getAll(), "dumped contents match input");

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -55,7 +55,7 @@ tape('read', function(assert) {
 
     // find the indexes of all the keys that start with f
     var f = [];
-    for (let i = 0; i < words.length; i++) if (words[i].charAt(0) == 'f') f.push(i);
+    for (var i = 0; i < words.length; i++) if (words[i].charAt(0) == 'f') f.push(i);
     assert.deepEqual(cache.getPrefixRange(f[0], f.length), [words.indexOf('1st st')], 'found normalization for 1st st but not frank boulevard');
 
     assert.deepEqual(cache.getPrefixRange(words.indexOf('frank boulevard'), 1), [words.indexOf('frank blvd')], 'found frank boulevard because no prefixes are shared');

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -45,6 +45,10 @@ tape('write/dump', function(assert) {
 
     assert.deepEqual(map, cache.getAll(), "dumped contents match input");
 
+    // test some invalid input
+    assert.throws(function() { cache.writeBatch(); });
+    assert.throws(function() { cache.writeBatch(7); });
+
     return assert.end();
 });
 
@@ -52,6 +56,7 @@ tape('read', function(assert) {
     var cache = new carmenCache.NormalizationCache(file, true);
 
     assert.equal(cache.get(words.indexOf('first street')), words.indexOf('1st st'));
+    assert.equal(cache.get(8888), undefined);
 
     // find the indexes of all the keys that start with f
     var f = [];
@@ -59,6 +64,24 @@ tape('read', function(assert) {
     assert.deepEqual(cache.getPrefixRange(f[0], f.length), [words.indexOf('1st st')], 'found normalization for 1st st but not frank boulevard');
 
     assert.deepEqual(cache.getPrefixRange(words.indexOf('frank boulevard'), 1), [words.indexOf('frank blvd')], 'found frank boulevard because no prefixes are shared');
+
+    // test some invalid input
+    assert.throws(function() { new carmenCache.NormalizationCache() });
+    assert.throws(function() { new carmenCache.NormalizationCache(7) });
+    assert.throws(function() { new carmenCache.NormalizationCache('asdf', 7) });
+
+    assert.throws(function() { new carmenCache.NormalizationCache('/proc', true) });
+
+
+    assert.throws(function() { cache.get() });
+    assert.throws(function() { cache.getPrefixRange('asdf') });
+
+    assert.throws(function() { cache.getPrefixRange() });
+    assert.throws(function() { cache.getPrefixRange('asdf') });
+    assert.throws(function() { cache.getPrefixRange('asdf', 'asdf') });
+    assert.throws(function() { cache.getPrefixRange(1, 'asdf') });
+    assert.throws(function() { cache.getPrefixRange(1, 1, 'asdf') });
+    assert.throws(function() { cache.getPrefixRange(1, 1, 1, 'asdf') });
 
     assert.end();
 });


### PR DESCRIPTION
This PR adds a new class to carmen-cache that stores an int-to-int mapping in a rocksdb database. It has pretty much nothing to do with existing carmen-cache classes, but this was a convenient place to put this functionality given that we already have the infrastructure necessary to build against rocksdb.

It does a few things:
* store and retrieve int->int mappings
* given a range of ints, it can search through that range of keys and return all values outside the range.

Used as the accompanying storage for https://github.com/mapbox/dawg-cache/pull/17, this allows expressing the concept "search through all the keys that start with X and give me any values they map to that don't also start with X."