### PR TITLE
Multivariate calculus

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.19.0",
+  "version": "0.19.0-mc-1",
   "dependencies": {
     "node-pre-gyp": "~0.6.32",
     "nan": "~2.5.1",


### PR DESCRIPTION
This PR modifies the normalization cache to make it able to represent situations where a single phrase might normalize to multiple phrases within the index, by storing multiple integers in sequence as values in the normalization rocksdb database.

The new version can read and use databases created by the existing version without modification. Databases created by the new version can be used without error by the existing version but may not retrieve all normalization values from the database. The interface presented to Carmen has also changed, such that the get methods now return arrays instead of scalars, and the set methods accept arrays as well as scalars.