### PR TITLE
Fix LTO on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,9 +1,5 @@
 {
     'includes': [ 'common.gypi' ],
-    'make_global_settings': [
-        ['CXX', '<(module_root_dir)/mason_packages/.link/bin/clang++-3.9'],
-        ['LINK', '<(module_root_dir)/mason_packages/.link/bin/clang++-3.9']
-    ],
     "variables": {
         # Flags we pass to the compiler to ensure the compiler
         # warns us about potentially buggy or dangerous code

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -22,6 +22,6 @@ if [[ ! -f mason_packages/.link/lib/librocksdb.a ]]; then
 fi
 
 mason link bzip2 1.0.6
-mason link rocksdb 4.13
+MASON_CONCURRENCY=2 mason link rocksdb 4.13
 mason install protozero 1.5.1
 mason link protozero 1.5.1

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,16 +3,25 @@
 set -eu
 set -o pipefail
 
-function install() {
-  mason install $1 $2
-  mason link $1 $2
-}
+# gyp will put "MAKEFLAGS=r -- BUILDTYPE=Release" into the makefiles
+# which breaks the rocksdb build
+unset MAKEFLAGS
 
 # setup mason
 ./scripts/setup.sh --config local.env
 source local.env
 
-install bzip2 1.0.6
-install rocksdb 4.13
-install clang++ 3.9.1
-install protozero 1.5.1
+# only build from source if it does not exist
+if [[ ! -f mason_packages/.link/lib/libbz2.a ]]; then
+    mason build bzip2 1.0.6
+fi
+
+# only build from source if it does not exist
+if [[ ! -f mason_packages/.link/lib/librocksdb.a ]]; then
+    mason build rocksdb 4.13
+fi
+
+mason link bzip2 1.0.6
+mason link rocksdb 4.13
+mason install protozero 1.5.1
+mason link protozero 1.5.1

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -11,6 +11,10 @@ unset MAKEFLAGS
 ./scripts/setup.sh --config local.env
 source local.env
 
+# avoid mis-reporting of CPU due to docker
+# from resulting in OOM killer knocking out g++
+export MASON_CONCURRENCY=2
+
 # only build from source if it does not exist
 if [[ ! -f mason_packages/.link/lib/libbz2.a ]]; then
     mason build bzip2 1.0.6
@@ -22,6 +26,6 @@ if [[ ! -f mason_packages/.link/lib/librocksdb.a ]]; then
 fi
 
 mason link bzip2 1.0.6
-MASON_CONCURRENCY=2 mason link rocksdb 4.13
+mason link rocksdb 4.13
 mason install protozero 1.5.1
 mason link protozero 1.5.1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,7 +77,7 @@ function run() {
 
     echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
     echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
-    echo "export CC=${CC:-llvm_toolchain_dir}/bin/clang" >> ${config}
+    echo "export CC=${CC:-${llvm_toolchain_dir}/bin/clang" >> ${config}
     echo 'export MASON_CXX=${CXX}' >> ${config}
     echo 'export MASON_CC=${CC}' >> ${config}
     echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -67,7 +67,7 @@ function run() {
 
 
     # install binutils for LTO on linux
-    if [[ $(uname -s) == 'Linux' ]]; then
+    if [[ $(uname -s) == 'Linux' ]] && [[ ${CXX:-} =~ 'clang++' ]]; then
       $(pwd)/.mason/mason install binutils ${BINUTILS_VERSION}
       $(pwd)/.mason/mason link binutils ${BINUTILS_VERSION}
     fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,7 +77,7 @@ function run() {
 
     echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
     echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
-    echo "export CC=${llvm_toolchain_dir}/bin/clang" >> ${config}
+    echo "export CC=${CC:-llvm_toolchain_dir}/bin/clang" >> ${config}
     echo 'export MASON_CXX=${CXX}' >> ${config}
     echo 'export MASON_CC=${CC}' >> ${config}
     echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,9 @@
 set -eu
 set -o pipefail
 
+# TODO(springmeyer) currently depends on mason branch: https://github.com/mapbox/mason/issues/566
 export MASON_RELEASE="${MASON_RELEASE:-cxx-override}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.1}"
 export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 
 PLATFORM=$(uname | tr A-Z a-z)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,7 +77,7 @@ function run() {
 
     echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
     echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
-    echo "export CC=${CC:-${llvm_toolchain_dir}/bin/clang" >> ${config}
+    echo "export CC=${CC:-${llvm_toolchain_dir}/bin/clang}" >> ${config}
     echo 'export MASON_CXX=${CXX}' >> ${config}
     echo 'export MASON_CC=${CC}' >> ${config}
     echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-v0.18.0}"
+export MASON_RELEASE="${MASON_RELEASE:-cxx-override}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 
@@ -77,6 +77,9 @@ function run() {
 
     echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
     echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
+    echo "export CC=${llvm_toolchain_dir}/bin/clang" >> ${config}
+    echo 'export MASON_CXX=${CXX}' >> ${config}
+    echo 'export MASON_CC=${CC}' >> ${config}
     echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}
     echo "export MASON_LLVM_RELEASE=${MASON_LLVM_RELEASE}" >> ${config}
     # https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso


### PR DESCRIPTION
This is a fix on top of the `cache-split` branch. It should fix LTO on linux by:

- ensuring we're using a consistent compiler (clang++ via mason, setup via the scripts/setup.sh script)
  - NOTE: I have dreams of a `mbxcxx` command that we use to do this in the future (rather than this clumsy `scripts/setup.sh` copied everywhere)
- ensure that the same compile is used to compile and link all binaries (important for being able to blend LTO binaries with other libraries).

Should fix https://github.com/mapbox/carmen-cache/issues/117#issuecomment-369051742