### PR TITLE
Better npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,6 @@
 /lib/carmen.node
 /mason
 /mason_packages
+/.mason/
+/.toolchain/
+/local.env

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,6 @@
 /lib/carmen.node
 /mason
 /mason_packages
-/.mason/
-/.toolchain/
+/.mason
+/.toolchain
 /local.env


### PR DESCRIPTION
# Context

Our recent npm packages include our whole mason toolchain unnecessarily. The relevant directories are excluded from git but not from npm, so this PR updates the npmignore to match.

# Next steps

- [x] wait for tests to pass
- [x] merge
- [ ] push a new commit straight to master that both bumps the version number and also contains the string `[publish binary]` in the commit message; don't tag it yet to avoid https://github.com/mapbox/node-cpp-skel/issues/108
- [ ] wait for *those* tests to pass, which will indicate that the binaries were successfully built and pushed to s3
- [ ] push a tag for the new version
- [ ] publish to npm
- [ ] cut a carmen pr pointing at the new release, then roll up stream

Ordinarily we would cut a carmen PR before merging this one, but I don't think it will be instructive as we won't actually know if this particular problem is solved until we cut a new release.

cc @mattficke 