### PR TITLE
node v8 and v10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,37 @@ matrix:
     # linux publishable node v6
     - os: linux
       env: BUILDTYPE=release
+      node_js: 10
+    # linux publishable node v6/debug
+    - os: linux
+      env: BUILDTYPE=debug
+      node_js: 10
+    # linux publishable node v6
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 8
+    # linux publishable node v6/debug
+    - os: linux
+      env: BUILDTYPE=debug
+      node_js: 8
+    # linux publishable node v6
+    - os: linux
+      env: BUILDTYPE=release
       node_js: 6
     # linux publishable node v6/debug
     - os: linux
       env: BUILDTYPE=debug
       node_js: 6
+    # osx publishable node v6
+    - os: osx
+      osx_image: xcode8.2
+      env: BUILDTYPE=release
+      node_js: 10
+    # osx publishable node v6
+    - os: osx
+      osx_image: xcode8.2
+      env: BUILDTYPE=release
+      node_js: 8
     # osx publishable node v6
     - os: osx
       osx_image: xcode8.2

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
   },
   "version": "0.21.1",
   "dependencies": {
-    "nan": "~2.5.1",
-    "node-pre-gyp": "~0.6.32",
-    "protozero": "~1.5.1"
+    "nan": "~2.10.0",
+    "node-pre-gyp": "~0.10.1"
   },
   "scripts": {
     "test": "tape test/*.test.js bench/*.js && eslint *.js test/*.js bench/*.js",
@@ -21,14 +20,19 @@
     "docs": "documentation build src/*.cpp --polyglot -f md -o API.md"
   },
   "eslintConfig": {
-    "plugins": ["tape"],
+    "plugins": [
+      "tape"
+    ],
     "extends": [
-        "@mapbox/eslint-config-geocoding"
+      "@mapbox/eslint-config-geocoding"
     ],
     "rules": {
-        "tape/assertion-message": ["error", "always"],
-        "tape/use-t": "error",
-        "tape/use-test": "error"
+      "tape/assertion-message": [
+        "error",
+        "always"
+      ],
+      "tape/use-t": "error",
+      "tape/use-test": "error"
     }
   },
   "devDependencies": {

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -27,5 +27,5 @@ fi
 
 mason link bzip2 1.0.6
 mason link rocksdb 4.13
-mason install protozero 1.5.1
-mason link protozero 1.5.1
+mason install protozero 1.6.2
+mason link protozero 1.6.2

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -519,11 +519,11 @@ NAN_METHOD(RocksDBCache::merge) {
     if (!info[3]->IsString()) return Nan::ThrowTypeError("argument 4 must be a String (method)");
     if (!info[4]->IsFunction()) return Nan::ThrowTypeError("argument 5 must be a callback function");
 
-    std::string in1 = *String::Utf8Value(info[0]->ToString());
-    std::string in2 = *String::Utf8Value(info[1]->ToString());
-    std::string out = *String::Utf8Value(info[2]->ToString());
+    std::string in1 = *Nan::Utf8String(info[0]->ToString());
+    std::string in2 = *Nan::Utf8String(info[1]->ToString());
+    std::string out = *Nan::Utf8String(info[2]->ToString());
     Local<Value> callback = info[4];
-    std::string method = *String::Utf8Value(info[3]->ToString());
+    std::string method = *Nan::Utf8String(info[3]->ToString());
 
     MergeBaton* baton = new MergeBaton();
     baton->filename1 = in1;


### PR DESCRIPTION
This PR adds node v8 and v10 support.


NOTE: It does not attempt to deal with the new node v10 deprecation warnings around `Nan::MakeCallback`. To handle those I recommend porting the async code to use https://github.com/nodejs/nan/blob/master/doc/asyncworker.md#nanasyncworker rather than direct libuv calls. Then the code will be modern and this deprecation warning will also be avoided:

```
./src/rocksdbcache.cpp:410:14: warning: 'MakeCallback' is deprecated [-Wdeprecated-declarations]
        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(baton->callback), 1, argv);
             ^
```

refs https://github.com/mapbox/core-tech/issues/381