### PR TITLE
Portable rocksdb

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.2",
+  "version": "0.21.2-portable",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -22,10 +22,10 @@ fi
 
 # only build from source if it does not exist
 if [[ ! -f mason_packages/.link/lib/librocksdb.a ]]; then
-    mason build rocksdb 4.13
+    mason build rocksdb 4.13-dev
 fi
 
 mason link bzip2 1.0.6
-mason link rocksdb 4.13
+mason link rocksdb 4.13-dev
 mason install protozero 1.6.2
 mason link protozero 1.6.2

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # TODO(springmeyer) currently depends on mason branch: https://github.com/mapbox/mason/issues/566
-export MASON_RELEASE="${MASON_RELEASE:-cxx-override}"
+export MASON_RELEASE="${MASON_RELEASE:-1605622}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.1}"
 export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # TODO(springmeyer) currently depends on mason branch: https://github.com/mapbox/mason/issues/566
-export MASON_RELEASE="${MASON_RELEASE:-1605622}"
+export MASON_RELEASE="${MASON_RELEASE:-39ca1b3}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.1}"
 export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 


### PR DESCRIPTION
This branch fixes #124 by switching to a portable build of RocksDB that should work on all architectures.

Changes:
- [x] switch to a different Mason gitsha
- [x] Switch to a dev package of RocksDB 4.13