### PR TITLE
Optimize coalesce

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.3",
+  "version": "0.21.3-optimize",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -473,7 +473,7 @@ void coalesceMulti(uv_work_t* req) {
         double maxrelev = 0;
         for (auto const& subq : stack) {
             zoomCache.emplace_back();
-            auto & zooms = zoomCache.back();
+            auto& zooms = zoomCache.back();
             std::vector<bool> zoomUniq(22, false);
             for (auto const& subqB : stack) {
                 if (subq.idx == subqB.idx) continue;
@@ -606,7 +606,7 @@ void coalesceMulti(uv_work_t* req) {
                         }
                     }
                 }
-                maxrelev = std::max(maxrelev,context_relev);
+                maxrelev = std::max(maxrelev, context_relev);
                 if (last) {
                     // Slightly penalize contexts that have no stacking
                     if (covers.size() == 1) {
@@ -615,7 +615,7 @@ void coalesceMulti(uv_work_t* req) {
                     } else if (covers[0].mask > covers[1].mask) {
                         context_relev -= 0.01;
                     }
-                    if (maxrelev - context_relev < .25 ) {
+                    if (maxrelev - context_relev < .25) {
                         contexts.emplace_back(std::move(covers), context_mask, context_relev);
                     }
                 } else if (first || covers.size() > 1) {
@@ -636,7 +636,7 @@ void coalesceMulti(uv_work_t* req) {
         // append coalesced to contexts by moving memory
         for (auto&& matched : coalesced) {
             for (auto&& context : matched.second) {
-                if (maxrelev - context.relev < .25 ) {
+                if (maxrelev - context.relev < .25) {
                     contexts.emplace_back(std::move(context));
                 }
             }

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -569,7 +569,7 @@ void coalesceMulti(uv_work_t* req) {
                 uint64_t zxy = (z * POW2_28) + (cover.x * POW2_14) + (cover.y);
 
                 std::vector<Cover> covers;
-                covers.push_back(cover);
+                covers.push_back(std::move(cover));
                 uint32_t context_mask = cover.mask;
                 double context_relev = cover.relev;
 

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -115,7 +115,6 @@ struct Cover {
     Cover& operator=(Cover const& c) = delete;
     Cover& operator=(Cover&& c) = default;
     Cover(Cover&& c) = default;
-
 };
 
 struct Context {

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -109,6 +109,13 @@ struct Cover {
     double distance;
     double scoredist;
     bool matches_language;
+
+    Cover() = default;
+    Cover(Cover const& c) = default;
+    Cover& operator=(Cover const& c) = delete;
+    Cover& operator=(Cover&& c) = default;
+    Cover(Cover&& c) = default;
+
 };
 
 struct Context {

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -82,11 +82,11 @@ intarray __getmatching(RocksDBCache const* c, std::string phrase, bool match_pre
 
         if (vals.first != vals.second) {
             value_type unadjusted_lastval = *(vals.first);
-            grids.emplace_back(sortableGrid{
+            grids.emplace_back(
                 vals.first,
                 vals.second,
                 unadjusted_lastval,
-                matches_language});
+                matches_language);
             rh.push(matches_language ? unadjusted_lastval | LANGUAGE_MATCH_BOOST : unadjusted_lastval, grids.size() - 1);
         }
     }

--- a/src/rocksdbcache.hpp
+++ b/src/rocksdbcache.hpp
@@ -31,9 +31,9 @@ namespace carmen {
 
 struct sortableGrid {
     sortableGrid(protozero::const_varint_iterator<uint64_t> _it,
-            protozero::const_varint_iterator<uint64_t> _end,
-            value_type _unadjusted_lastval,
-            bool _matches_language)
+                 protozero::const_varint_iterator<uint64_t> _end,
+                 value_type _unadjusted_lastval,
+                 bool _matches_language)
         : it(_it),
           end(_end),
           unadjusted_lastval(_unadjusted_lastval),

--- a/src/rocksdbcache.hpp
+++ b/src/rocksdbcache.hpp
@@ -30,10 +30,24 @@ namespace carmen {
 #define PREFIX_MAX_GRID_LENGTH 500000
 
 struct sortableGrid {
+    sortableGrid(protozero::const_varint_iterator<uint64_t> _it,
+            protozero::const_varint_iterator<uint64_t> _end,
+            value_type _unadjusted_lastval,
+            bool _matches_language)
+        : it(_it),
+          end(_end),
+          unadjusted_lastval(_unadjusted_lastval),
+          matches_language(_matches_language) {
+    }
     protozero::const_varint_iterator<uint64_t> it;
     protozero::const_varint_iterator<uint64_t> end;
     value_type unadjusted_lastval;
     bool matches_language;
+    sortableGrid() = delete;
+    sortableGrid(sortableGrid const& c) = delete;
+    sortableGrid& operator=(sortableGrid const& c) = delete;
+    sortableGrid& operator=(sortableGrid&& c) = default;
+    sortableGrid(sortableGrid&& c) = default;
 };
 
 struct MergeBaton : carmen::noncopyable {


### PR DESCRIPTION
This branch optimizes the `coalesce` function in these ways:

 - It pre-filters `context` objects using `relev` score to mitigate the size of the `std::vector<Context>` object before sorting
 - It reverts [several calls to `vector.reserve`](https://github.com/mapbox/carmen-cache/commit/1d55d3d63c09e40b2483d36a75a0f1787b3a3040) that were, based on profiling, incurring more overhead than efficiency gains because they were overallocating memory that was never written to. The rule of thumb should be to only call reserve when we know for sure that we'll use all the memory. Otherwise incurring re-allocation overhead will be less of a cost than over-allocating up front.
 - It makes several classes movable, such that re-allocation of these objects in vectors (during growth or sorting) should be faster, since they'll use move semantics.


@apendleton @aaaandrea - I've published `dev` binaries for this, but have not done more. Could you take over here to:

 - [x] Check if this works in carmen
 - [x] See if it increases performance in the places that matter


#### Open questions

 - Is the `relev` pre-filtering okay, or could it break something? If it breaks something downstream, does that mean we are missing critical test coverage here?
 - The bottleneck that remained in local profiling was `__getmatching` and this PR does nothing to speed this up - no ideas there.
 - I noticed that in profiling the main event loop as doing about 40% in copying objects from C++ to JS and the threads were about 20% in `__getmatching` and 80% idle. I'm not sure why the threads are not more busy - could memory allocations or locking in rocksdb be slowing down the ability to dispatch more work to the threads?
 - In local profiling (with the bench data @apendleton provided) I did not see that `carmen::ContextSortByRelev` as a significant bottleneck like I did previously in production (refs #120). Does this mean that things have changed or that the benchmark does not represent the production load that was placed on the machines when we got the traces from #120?