### PR TITLE
Reduce cross-language penalty

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.4-xlang",
+  "version": "0.21.4-xlang-2",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.4",
+  "version": "0.21.4-xlang",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # TODO(springmeyer) currently depends on mason branch: https://github.com/mapbox/mason/issues/566
-export MASON_RELEASE="${MASON_RELEASE:-39ca1b3}"
+export MASON_RELEASE="${MASON_RELEASE:-e7d5cbe}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.1}"
 export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -401,7 +401,7 @@ void coalesceSingle(uv_work_t* req) {
             cover.idx = subq.idx;
             cover.tmpid = static_cast<uint32_t>(cover.idx * POW2_25 + cover.id);
             cover.relev = cover.relev * subq.weight;
-            if (!cover.matches_language) cover.relev *= .9;
+            if (!cover.matches_language) cover.relev *= .96;
             cover.distance = proximity ? tileDist(cx, cy, cover.x, cover.y) : 0;
             cover.scoredist = proximity ? scoredist(cz, cover.distance, cover.score, baton->radius) : cover.score;
 
@@ -550,7 +550,7 @@ void coalesceMulti(uv_work_t* req) {
                 cover.mask = subq.mask;
                 cover.tmpid = static_cast<uint32_t>(cover.idx * POW2_25 + cover.id);
                 cover.relev = cover.relev * subq.weight;
-                if (!cover.matches_language) cover.relev *= .9;
+                if (!cover.matches_language) cover.relev *= .96;
                 if (proximity) {
                     ZXY dxy = pxy2zxy(z, cover.x, cover.y, cz);
                     cover.distance = tileDist(cx, cy, dxy.x, dxy.y);

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -507,10 +507,10 @@ test('coalesce args', (t) => {
                 t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
                 t.deepEqual(res[1].relev, 1, '1.relev');
                 t.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
-                t.deepEqual(res[2].relev, 0.9, '2.relev');
-                t.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
-                t.deepEqual(res[3].relev, 0.9, '3.relev');
-                t.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[2].relev, 0.96, '2.relev');
+                t.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.96, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[3].relev, 0.96, '3.relev');
+                t.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.96, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
                 t.end();
             });
         });
@@ -527,14 +527,14 @@ test('coalesce args', (t) => {
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 4, 'got back 4 results');
-                t.deepEqual(res[0].relev, 0.9, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 1, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
-                t.deepEqual(res[1].relev, 0.9, '1.relev');
-                t.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
-                t.deepEqual(res[2].relev, 0.9, '2.relev');
-                t.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 3, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
-                t.deepEqual(res[3].relev, 0.9, '3.relev');
-                t.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.9, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[0].relev, 0.96, '0.relev');
+                t.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 1, idx: 0, relev: 0.96, score: 0, scoredist: 0, tmpid: 1, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[1].relev, 0.96, '1.relev');
+                t.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 2, idx: 0, relev: 0.96, score: 0, scoredist: 0, tmpid: 2, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[2].relev, 0.96, '2.relev');
+                t.deepEqual(res[2][0], { matches_language: false, distance: 0, id: 3, idx: 0, relev: 0.96, score: 0, scoredist: 0, tmpid: 3, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[3].relev, 0.96, '3.relev');
+                t.deepEqual(res[3][0], { matches_language: false, distance: 0, id: 4, idx: 0, relev: 0.96, score: 0, scoredist: 0, tmpid: 4, x: 1, y: 1 }, '0.0');
                 t.end();
             });
         });
@@ -743,9 +743,9 @@ test('coalesce args', (t) => {
                 t.deepEqual(res[0].relev, 1, '0.relev');
                 t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
                 t.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
-                // one of our indexes has languages and the other does not, so relev will be 0.95 because it's (.5 + .9*.5)
-                t.deepEqual(res[1].relev, 0.95, '1.relev');
-                t.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.45, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                // one of our indexes has languages and the other does not, so relev will be 0.98 because it's (.5 + .9*.5)
+                t.deepEqual(res[1].relev, 0.98, '1.relev');
+                t.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.48, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
                 t.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
                 t.end();
             });
@@ -771,12 +771,12 @@ test('coalesce args', (t) => {
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
-                t.deepEqual(res[0].relev, 0.95, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 2, idx: 1, relev: 0.45, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[0].relev, 0.98, '0.relev');
+                t.deepEqual(res[0][0], { matches_language: false, distance: 0, id: 2, idx: 1, relev: 0.48, score: 1, scoredist: 1, tmpid: 33554434, x: 1, y: 1 }, '0.0');
                 t.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
                 // one of our indexes has languages and the other does not, so relev will be 0.9 because it's (.5 + .8*.5)
-                t.deepEqual(res[1].relev, 0.95, '1.relev');
-                t.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.45, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
+                t.deepEqual(res[1].relev, 0.98, '1.relev');
+                t.deepEqual(res[1][0], { matches_language: false, distance: 0, id: 3, idx: 1, relev: 0.48, score: 1, scoredist: 1, tmpid: 33554435, x: 1, y: 1 }, '1.0');
                 t.deepEqual(res[1][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
                 t.end();
             });


### PR DESCRIPTION
This PR reduces the penalty applied to out-of-language matches from 10% to 4%, and correspondingly updates test fixtures for the new expected value.

It also switches to a new Mason gitsha, which fixes an upstream Mason issue where builds depending on bzip started failing because the bzip.org domain expired; see https://github.com/mapbox/mason/pull/648