### PR TITLE
[testing] Remove prefiltering

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.5",
+  "version": "0.21.5-noprefilter",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -606,7 +606,6 @@ void coalesceMulti(uv_work_t* req) {
                         }
                     }
                 }
-                maxrelev = std::max(maxrelev, context_relev);
                 if (last) {
                     // Slightly penalize contexts that have no stacking
                     if (covers.size() == 1) {
@@ -615,9 +614,7 @@ void coalesceMulti(uv_work_t* req) {
                     } else if (covers[0].mask > covers[1].mask) {
                         context_relev -= 0.01;
                     }
-                    if (maxrelev - context_relev < .25) {
-                        contexts.emplace_back(std::move(covers), context_mask, context_relev);
-                    }
+                    contexts.emplace_back(std::move(covers), context_mask, context_relev);
                 } else if (first || covers.size() > 1) {
                     cit = coalesced.find(zxy);
                     if (cit == coalesced.end()) {
@@ -636,9 +633,7 @@ void coalesceMulti(uv_work_t* req) {
         // append coalesced to contexts by moving memory
         for (auto&& matched : coalesced) {
             for (auto&& context : matched.second) {
-                if (maxrelev - context.relev < .25) {
-                    contexts.emplace_back(std::move(context));
-                }
+                contexts.emplace_back(std::move(context));
             }
         }
 


### PR DESCRIPTION
This reverts part of #126 because I'm worried it could be, despite all unit test passing here in carmen-cache, cause a regression in results. The concern would be that the prefiltering throws out results which might not be thrown out after the 40 context limit later on in the coalescing.

The original motivation of this change was to increase performance by reducing the number of results that needed to be sorted internally.

This PR is intended to help test whether this change could potentially be a source of regressions in desirable results so we can have quick data to consider the tradeoffs of perf and results quality.
