### PR TITLE
[WIP] More sensitive prefix autocomplete handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To build from source run:
 
 ```
 make
+npm test
 ```
 
 This will automatically:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ carmen-cache
 To install `carmen-cache` run:
 
 ```
-npm install
+yarn install
 ```
 
 By default, binaries are provided for `64 bit OS X >= 10.8` and `64 bit Linux (>= Ubuntu Trusty)`. On those platforms no external dependencies are needed.
@@ -25,7 +25,7 @@ To build from source run:
 
 ```
 make
-npm test
+yarn test
 ```
 
 This will automatically:

--- a/bench/coalesce.bench.test.js
+++ b/bench/coalesce.bench.test.js
@@ -14,7 +14,7 @@ const test = require('tape');
         zoom: 14,
         weight: 1,
         phrase: '3848571113',
-        prefix: false,
+        prefix: 0,
         mask: 1 << 0
     }];
     test('coalesceSingle', (t) => {
@@ -84,7 +84,7 @@ const test = require('tape');
         zoom: 12,
         weight: 0.25,
         phrase: '1965155344',
-        prefix: false
+        prefix: 0
     }, {
         cache: b,
         mask: 1 << 1,
@@ -92,7 +92,7 @@ const test = require('tape');
         zoom: 14,
         weight: 0.75,
         phrase: '3848571113',
-        prefix: false
+        prefix: 0
     }];
     test('coalesceMulti', (t) => {
         const time = +new Date;

--- a/index.js
+++ b/index.js
@@ -1,2 +1,8 @@
 'use strict';
 exports = module.exports = require('./lib/carmen.node');
+
+exports.PREFIX_SCAN = {
+    disabled: 0,
+    enabled: 1,
+    word_boundary: 2
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.5",
+  "version": "0.21.5-rocksdb-update",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   },
   "devDependencies": {
     "@mapbox/eslint-config-geocoding": "^1.0.1",
-    "eslint-plugin-tape": "1.1.0",
     "aws-sdk": "^2.55.0",
     "documentation": "^4.0.0-beta5",
     "eslint": "^4.17.0",
     "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-tape": "1.1.0",
     "tape": "^4.6.3"
   },
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.21.5-rocksdb-update",
+  "version": "0.21.5-word-boundary",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -15,17 +15,7 @@ source local.env
 # from resulting in OOM killer knocking out g++
 export MASON_CONCURRENCY=2
 
-# only build from source if it does not exist
-if [[ ! -f mason_packages/.link/lib/libbz2.a ]]; then
-    mason build bzip2 1.0.6
-fi
-
-# only build from source if it does not exist
-if [[ ! -f mason_packages/.link/lib/librocksdb.a ]]; then
-    mason build rocksdb 4.13-dev
-fi
-
-mason link bzip2 1.0.6
-mason link rocksdb 4.13-dev
-mason install protozero 1.6.2
+mason install clang++ 3.9.1
+mason install bzip2 1.0.6
+mason install rocksdb 5.3.6
 mason link protozero 1.6.2

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -17,5 +17,9 @@ export MASON_CONCURRENCY=2
 
 mason install clang++ 3.9.1
 mason install bzip2 1.0.6
-mason install rocksdb 5.3.6
+mason install rocksdb 5.4.6
+mason install protozero 1.6.2
+
+mason link bzip2 1.0.6
 mason link protozero 1.6.2
+mason link rocksdb 5.4.6

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,7 @@
 set -eu
 set -o pipefail
 
-# TODO(springmeyer) currently depends on mason branch: https://github.com/mapbox/mason/issues/566
-export MASON_RELEASE="${MASON_RELEASE:-e7d5cbe}"
+export MASON_RELEASE="${MASON_RELEASE:-v0.19.0}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.1}"
 export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -183,7 +183,6 @@ NAN_METHOD(coalesce) {
                     return Nan::ThrowTypeError("prefix value must be a integer between 0 - 2");
                 }
                 prefix = static_cast<PrefixMatch>(prop_val->Int32Value());
-
             }
 
             if (!jsStack->Has(Nan::New("mask").ToLocalChecked())) {

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -16,7 +16,7 @@ using namespace v8;
  * @type {Object}
  * @property {String} phrase - The matched string
  * @property {Number} weight - A float between 0 and 1 representing how much of the query this string covers
- * @property {Boolean} prefix - whether or not to do a prefix scan (as opposed to an exact match scan); used for autocomplete
+ * @property {Number} prefix - whether or do an exact match (0), prefix scan(1), or word boundry scan(2); used for autocomplete
  * @property {Number} idx - an identifier of the index the match came from; opaque to carmen-cache but returned in results
  * @property {Number} zoom - the configured tile zoom level for the index
  * @property {Number} mask - a bitmask representing which tokens in the original query the subquery covers
@@ -111,7 +111,7 @@ NAN_METHOD(coalesce) {
 
             double weight;
             std::string phrase;
-            bool prefix;
+            PrefixMatch prefix;
             unsigned short idx;
             unsigned short zoom;
             uint32_t mask;
@@ -178,10 +178,12 @@ NAN_METHOD(coalesce) {
                 return Nan::ThrowTypeError("missing prefix property");
             } else {
                 Local<Value> prop_val = jsStack->Get(Nan::New("prefix").ToLocalChecked());
-                if (!prop_val->IsBoolean()) {
-                    return Nan::ThrowTypeError("prefix value must be a boolean");
+                if (!prop_val->IsNumber()) {
+                    // TODO check value is 0-2
+                    return Nan::ThrowTypeError("prefix value must be a integer between 0 - 2");
                 }
-                prefix = prop_val->BooleanValue();
+                prefix = static_cast<PrefixMatch>(prop_val->Int32Value());
+
             }
 
             if (!jsStack->Has(Nan::New("mask").ToLocalChecked())) {

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -179,10 +179,14 @@ NAN_METHOD(coalesce) {
             } else {
                 Local<Value> prop_val = jsStack->Get(Nan::New("prefix").ToLocalChecked());
                 if (!prop_val->IsNumber()) {
-                    // TODO check value is 0-2
                     return Nan::ThrowTypeError("prefix value must be a integer between 0 - 2");
                 }
-                prefix = static_cast<PrefixMatch>(prop_val->Int32Value());
+
+                int32_t int32_prefix = prop_val->Int32Value();
+                if (int32_prefix < 0 || int32_prefix > 2) {
+                    return Nan::ThrowTypeError("prefix value must be a integer between 0 - 2");
+                }
+                prefix = static_cast<PrefixMatch>(int32_prefix);
             }
 
             if (!jsStack->Has(Nan::New("mask").ToLocalChecked())) {

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -16,7 +16,7 @@ using namespace v8;
  * @type {Object}
  * @property {String} phrase - The matched string
  * @property {Number} weight - A float between 0 and 1 representing how much of the query this string covers
- * @property {Number} prefix - whether or do an exact match (0), prefix scan(1), or word boundry scan(2); used for autocomplete
+ * @property {Number} prefix - whether or do an exact match (0), prefix scan(1), or word boundary scan(2); used for autocomplete
  * @property {Number} idx - an identifier of the index the match came from; opaque to carmen-cache but returned in results
  * @property {Number} zoom - the configured tile zoom level for the index
  * @property {Number} mask - a bitmask representing which tokens in the original query the subquery covers

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -44,7 +44,10 @@ class noncopyable {
     noncopyable& operator=(noncopyable const&) = delete;
 };
 
-typedef enum { disabled, enabled, word_boundry } PrefixMatch;
+typedef enum {
+    disabled,
+    enabled,
+    word_boundary } PrefixMatch;
 
 typedef unsigned __int128 langfield_type;
 constexpr uint64_t LANGUAGE_MATCH_BOOST = static_cast<const uint64_t>(1) << 63;

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -44,6 +44,8 @@ class noncopyable {
     noncopyable& operator=(noncopyable const&) = delete;
 };
 
+typedef enum { disabled, enabled, word_boundry } PrefixMatch;
+
 typedef unsigned __int128 langfield_type;
 constexpr uint64_t LANGUAGE_MATCH_BOOST = static_cast<const uint64_t>(1) << 63;
 
@@ -71,7 +73,7 @@ struct PhrasematchSubq {
                     char t,
                     double w,
                     std::string p,
-                    bool pf,
+                    PrefixMatch pf,
                     unsigned short i,
                     unsigned short z,
                     uint32_t m,
@@ -88,7 +90,7 @@ struct PhrasematchSubq {
     char type;
     double weight;
     std::string phrase;
-    bool prefix;
+    PrefixMatch prefix;
     unsigned short idx;
     unsigned short zoom;
     uint32_t mask;

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -47,7 +47,8 @@ class noncopyable {
 typedef enum {
     disabled,
     enabled,
-    word_boundary } PrefixMatch;
+    word_boundary
+} PrefixMatch;
 
 typedef unsigned __int128 langfield_type;
 constexpr uint64_t LANGUAGE_MATCH_BOOST = static_cast<const uint64_t>(1) << 63;

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -42,7 +42,7 @@ intarray __getmatching(MemoryCache const* c, std::string phrase, PrefixMatch mat
 
         if (memcmp(phrase_data, item_data, phrase_length) == 0) {
             if (match_prefixes == PrefixMatch::word_boundary) {
-                size_t end = phrase_length; // Unsure about this, assumes it's save to read that one more position into the string
+                size_t end = phrase_length;
                 if (item_data[end] != LANGFIELD_SEPARATOR && item_data[end] != ' ') {
                     continue;
                 }

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -28,7 +28,7 @@ intarray __get(MemoryCache const* c, std::string phrase, langfield_type langfiel
 intarray __getmatching(MemoryCache const* c, std::string phrase, PrefixMatch match_prefixes, langfield_type langfield) {
     intarray array;
 
-    if (!match_prefixes) phrase.push_back(LANGFIELD_SEPARATOR);
+    if (match_prefixes == PrefixMatch::disabled) phrase.push_back(LANGFIELD_SEPARATOR);
     size_t phrase_length = phrase.length();
     const char* phrase_data = phrase.data();
 
@@ -41,6 +41,12 @@ intarray __getmatching(MemoryCache const* c, std::string phrase, PrefixMatch mat
         if (item_length < phrase_length) continue;
 
         if (memcmp(phrase_data, item_data, phrase_length) == 0) {
+            if (match_prefixes == PrefixMatch::word_boundry) {
+                size_t end = phrase_length; // Unsure about this, assumes it's save to read that one more position into the string
+                if (item_data[end] != LANGFIELD_SEPARATOR && item_data[end] != ' ') {
+                    continue;
+                }
+            }
             langfield_type message_langfield = extract_langfield(item.first);
 
             if (message_langfield & langfield) {

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -41,7 +41,7 @@ intarray __getmatching(MemoryCache const* c, std::string phrase, PrefixMatch mat
         if (item_length < phrase_length) continue;
 
         if (memcmp(phrase_data, item_data, phrase_length) == 0) {
-            if (match_prefixes == PrefixMatch::word_boundry) {
+            if (match_prefixes == PrefixMatch::word_boundary) {
                 size_t end = phrase_length; // Unsure about this, assumes it's save to read that one more position into the string
                 if (item_data[end] != LANGFIELD_SEPARATOR && item_data[end] != ' ') {
                     continue;

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -25,7 +25,7 @@ intarray __get(MemoryCache const* c, std::string phrase, langfield_type langfiel
     return array;
 }
 
-intarray __getmatching(MemoryCache const* c, std::string phrase, bool match_prefixes, langfield_type langfield) {
+intarray __getmatching(MemoryCache const* c, std::string phrase, PrefixMatch match_prefixes, langfield_type langfield) {
     intarray array;
 
     if (!match_prefixes) phrase.push_back(LANGFIELD_SEPARATOR);

--- a/src/memorycache.hpp
+++ b/src/memorycache.hpp
@@ -41,7 +41,7 @@ class MemoryCache : public node::ObjectWrap {
 };
 
 intarray __get(MemoryCache const* c, std::string phrase, langfield_type langfield);
-intarray __getmatching(MemoryCache const* c, std::string phrase, bool match_prefixes, langfield_type langfield);
+intarray __getmatching(MemoryCache const* c, std::string phrase, PrefixMatch match_prefixes, langfield_type langfield);
 
 } // namespace carmen
 

--- a/src/node_util.hpp
+++ b/src/node_util.hpp
@@ -115,7 +115,6 @@ inline NAN_METHOD(_genericgetmatching) {
         return Nan::ThrowTypeError("first arg must be a String");
     }
     if (!info[1]->IsNumber()) {
-        // TODO check value is 0-2
         return Nan::ThrowTypeError("second arg must be a integer between 0 - 2");
     }
     try {
@@ -125,7 +124,11 @@ inline NAN_METHOD(_genericgetmatching) {
         }
         std::string id(*utf8_id);
 
-        PrefixMatch match_prefixes = static_cast<PrefixMatch>(info[1]->Int32Value());
+        int32_t int32_prefix = info[1]->Int32Value();
+        if (int32_prefix < 0 || int32_prefix > 2) {
+            return Nan::ThrowTypeError("second arg must be a integer between 0 - 2");
+        }
+        PrefixMatch match_prefixes = static_cast<PrefixMatch>(int32_prefix);
 
         langfield_type langfield;
         if (info.Length() > 2 && !(info[2]->IsNull() || info[2]->IsUndefined())) {

--- a/src/node_util.hpp
+++ b/src/node_util.hpp
@@ -114,8 +114,9 @@ inline NAN_METHOD(_genericgetmatching) {
     if (!info[0]->IsString()) {
         return Nan::ThrowTypeError("first arg must be a String");
     }
-    if (!info[1]->IsBoolean()) {
-        return Nan::ThrowTypeError("second arg must be a Bool");
+    if (!info[1]->IsNumber()) {
+        // TODO check value is 0-2
+        return Nan::ThrowTypeError("second arg must be a integer between 0 - 2");
     }
     try {
         Nan::Utf8String utf8_id(info[0]);

--- a/src/node_util.hpp
+++ b/src/node_util.hpp
@@ -124,7 +124,7 @@ inline NAN_METHOD(_genericgetmatching) {
         }
         std::string id(*utf8_id);
 
-        bool match_prefixes = info[1]->BooleanValue();
+        PrefixMatch match_prefixes = static_cast<PrefixMatch>(info[1]->Int32Value());
 
         langfield_type langfield;
         if (info.Length() > 2 && !(info[2]->IsNull() || info[2]->IsUndefined())) {

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -28,7 +28,7 @@ intarray __get(RocksDBCache const* c, std::string phrase, langfield_type langfie
     return array;
 }
 
-intarray __getmatching(RocksDBCache const* c, std::string phrase, bool match_prefixes, langfield_type langfield) {
+intarray __getmatching(RocksDBCache const* c, std::string phrase, PrefixMatch match_prefixes, langfield_type langfield) {
     intarray array;
 
     if (!match_prefixes) phrase.push_back(LANGFIELD_SEPARATOR);

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -34,6 +34,9 @@ intarray __getmatching(RocksDBCache const* c, std::string phrase, PrefixMatch ma
     if (match_prefixes == PrefixMatch::disabled) phrase.push_back(LANGFIELD_SEPARATOR);
 
     size_t phrase_length = phrase.length();
+    if (match_prefixes == PrefixMatch::word_boundary) {
+        phrase_length++;
+    }
 
     // Load values from message cache
     std::vector<std::tuple<std::string, bool>> messages;
@@ -56,12 +59,10 @@ intarray __getmatching(RocksDBCache const* c, std::string phrase, PrefixMatch ma
     for (rit->Seek(phrase); rit->Valid() && rit->key().ToString().compare(0, phrase.size(), phrase) == 0; rit->Next()) {
         std::string key = rit->key().ToString();
 
-        if (match_prefixes == PrefixMatch::word_boundry) {
-            // Unsure about this b/c we mutate the phrase above
-            size_t end = phrase_length;
-            if (phrase_length <= MEMO_PREFIX_LENGTH_T2) end += 2;
-
-            char endChar = key.at(end);
+        if (match_prefixes == PrefixMatch::word_boundary) {
+            // Read one character beyond the input prefix length, should always
+            // be safe because of the LANGFIELD_SEPARATOR
+            char endChar = key.at(phrase.length());
             if (endChar != LANGFIELD_SEPARATOR && endChar != ' ') {
                 continue;
             }

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -35,6 +35,9 @@ intarray __getmatching(RocksDBCache const* c, std::string phrase, PrefixMatch ma
 
     size_t phrase_length = phrase.length();
     if (match_prefixes == PrefixMatch::word_boundary) {
+        // If we're looking for a word boundary we need have one more character
+        // available than the phrase is long. Incrementing this lengh ensures we
+        // don't use a prefix cache that could cut off the word break.
         phrase_length++;
     }
 

--- a/src/rocksdbcache.hpp
+++ b/src/rocksdbcache.hpp
@@ -117,7 +117,7 @@ void mergeQueue(uv_work_t* req);
 void mergeAfter(uv_work_t* req, int status);
 
 intarray __get(RocksDBCache const* c, std::string phrase, langfield_type langfield);
-intarray __getmatching(RocksDBCache const* c, std::string phrase, bool match_prefixes, langfield_type langfield);
+intarray __getmatching(RocksDBCache const* c, std::string phrase, PrefixMatch match_prefixes, langfield_type langfield);
 
 } // namespace carmen
 

--- a/test/coalesce.proximity.test.js
+++ b/test/coalesce.proximity.test.js
@@ -7,6 +7,7 @@
 const MemoryCache = require('../index.js').MemoryCache;
 const Grid = require('./grid.js');
 const coalesce = require('../index.js').coalesce;
+const scan = require('../index.js').PREFIX_SCAN;
 const test = require('tape');
 
 (function() {
@@ -56,7 +57,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 + 15]
@@ -76,7 +77,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 - 15]
@@ -96,7 +97,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 - 15]
@@ -116,7 +117,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 + 15]

--- a/test/coalesce.proximity.test.js
+++ b/test/coalesce.proximity.test.js
@@ -56,7 +56,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 + 15]
@@ -76,7 +76,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 - 15]
@@ -96,7 +96,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 - 15]
@@ -116,7 +116,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 + 15]

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -61,7 +61,7 @@ test('coalesce args', (t) => {
         zoom: 2,
         weight: 1,
         phrase: 'a',
-        prefix: false
+        prefix: 0
     };
 
     t.throws(() => {
@@ -133,7 +133,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             },
             {
                 cache: new MemoryCache('b'),
@@ -142,7 +142,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }
         ];
 
@@ -205,48 +205,52 @@ test('coalesce args', (t) => {
     }, /Arg 3 must be a callback/, 'throws');
 
     t.throws(() => {
-        coalesce([{ mask: 1 << 0, idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ mask: 1 << 0, idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5, prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5, prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: '', mask: 1 << 0, idx: 1, weight: .5,  zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: '', mask: 1 << 0, idx: 1, weight: .5,  zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /cache value must be a Cache object/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /mask value must be a number/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /idx value must be a number/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: '1', prefix: 0 }],{},() => {});
     }, /zoom value must be a number/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /weight value must be a number/, 'throws');
+
+    t.throws(() => {
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: 0.5, zoom: 1, phrase: '1', prefix: false }],{},() => {});
+    }, /prefix value must be a integer between 0 - 2/, 'throws');
 
     t.throws(() => {
         coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: 1, phrase: '' }],{},() => {});
@@ -291,7 +295,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '0.relev');
@@ -311,7 +315,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [3,3,3]
             }, (err, res) => {
@@ -333,7 +337,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [2, 1, 1, 1, 1]
             }, (err, res) => {
@@ -380,7 +384,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.ok(res, 'got back a result');
@@ -420,7 +424,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'got back 2 results');
@@ -475,7 +479,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 4, 'got back 4 results');
@@ -498,7 +502,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -522,7 +526,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -598,7 +602,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -606,7 +610,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -627,7 +631,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -635,7 +639,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [2,3,3]
             }, (err, res) => {
@@ -698,7 +702,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -706,7 +710,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -727,7 +731,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -735,7 +739,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -758,7 +762,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -766,7 +770,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -827,7 +831,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -835,7 +839,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [14,4601,6200]
             }, (err, res) => {
@@ -854,7 +858,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -862,7 +866,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [14,4610,6200]
             }, (err, res) => {
@@ -920,7 +924,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -928,7 +932,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -1014,7 +1018,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1022,7 +1026,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1039,7 +1043,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1047,7 +1051,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [2, 0, 0, 1, 3]
             }, (err, res) => {
@@ -1064,7 +1068,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1072,7 +1076,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [6, 14, 30, 15, 64]
             }, (err, res) => {
@@ -1089,7 +1093,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: c,
                 mask: 1 << 0,
@@ -1097,7 +1101,7 @@ test('coalesce args', (t) => {
                 zoom: 5,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1160,7 +1164,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1168,7 +1172,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1226,7 +1230,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1234,7 +1238,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1298,7 +1302,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1306,7 +1310,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1314,7 +1318,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');
@@ -1332,7 +1336,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1340,7 +1344,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1348,7 +1352,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -3,6 +3,7 @@ const MemoryCache = require('../index.js').MemoryCache;
 const RocksDBCache = require('../index.js').RocksDBCache;
 const Grid = require('./grid.js');
 const coalesce = require('../index.js').coalesce;
+const scan = require('../index.js').PREFIX_SCAN;
 const test = require('tape');
 const fs = require('fs');
 
@@ -61,7 +62,7 @@ test('coalesce args', (t) => {
         zoom: 2,
         weight: 1,
         phrase: 'a',
-        prefix: 0
+        prefix: scan.disabled
     };
 
     t.throws(() => {
@@ -304,7 +305,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '0.relev');
@@ -324,7 +325,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [3,3,3]
             }, (err, res) => {
@@ -346,7 +347,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [2, 1, 1, 1, 1]
             }, (err, res) => {
@@ -393,7 +394,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.ok(res, 'got back a result');
@@ -433,7 +434,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'got back 2 results');
@@ -488,7 +489,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 4, 'got back 4 results');
@@ -511,7 +512,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -535,7 +536,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -611,7 +612,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -619,7 +620,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -640,7 +641,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -648,7 +649,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [2,3,3]
             }, (err, res) => {
@@ -711,7 +712,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -719,7 +720,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -740,7 +741,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -748,7 +749,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -771,7 +772,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -779,7 +780,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -840,7 +841,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -848,7 +849,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [14,4601,6200]
             }, (err, res) => {
@@ -867,7 +868,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -875,7 +876,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [14,4610,6200]
             }, (err, res) => {
@@ -933,7 +934,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -941,7 +942,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -1027,7 +1028,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1035,7 +1036,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1052,7 +1053,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1060,7 +1061,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [2, 0, 0, 1, 3]
             }, (err, res) => {
@@ -1077,7 +1078,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1085,7 +1086,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [6, 14, 30, 15, 64]
             }, (err, res) => {
@@ -1102,7 +1103,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: c,
                 mask: 1 << 0,
@@ -1110,7 +1111,7 @@ test('coalesce args', (t) => {
                 zoom: 5,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1173,7 +1174,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1181,7 +1182,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1239,7 +1240,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1247,7 +1248,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1311,7 +1312,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1319,7 +1320,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1327,7 +1328,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');
@@ -1345,7 +1346,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1353,7 +1354,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1361,7 +1362,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -253,6 +253,15 @@ test('coalesce args', (t) => {
     }, /prefix value must be a integer between 0 - 2/, 'throws');
 
     t.throws(() => {
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: 0.5, zoom: 1, phrase: '1', prefix: 3 }],{},() => {});
+    }, /prefix value must be a integer between 0 - 2/, 'throws on 3');
+
+    t.throws(() => {
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: 0.5, zoom: 1, phrase: '1', prefix: -1 }],{},() => {});
+    }, /prefix value must be a integer between 0 - 2/, 'throws on 3');
+
+
+    t.throws(() => {
         coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: 1, phrase: '' }],{},() => {});
     }, /encountered invalid phrase/, 'throws');
 

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -66,7 +66,7 @@ test('getMatching', (t) => {
         Grid.encode({ id: 73, x: 1, y: 1, relev: 1, score: 1 })
     ], [0]);
 
-    cache._set('word boundry', [
+    cache._set('word boundary', [
         Grid.encode({ id: 81, x: 1, y: 1, relev: 1, score: 1 }),
         Grid.encode({ id: 82, x: 1, y: 1, relev: 1, score: 1 }),
         Grid.encode({ id: 83, x: 1, y: 1, relev: 1, score: 1 })
@@ -214,8 +214,7 @@ test('getMatching', (t) => {
 
 
         t.false(c._getMatching('word', 0), "getMatching for 'word' with no prefix match returns nothing");
-        // TODO fix me, at the case where we're right at the memo prefix lenghts weird things can happen
-        // t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+        t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
         t.false(c._getMatching('word boun', 2), "getMatching for 'word boun' with word boundary prefix match returns nothing");
 
         const test_all_langs_prefix_8 = c._getMatching('wor', 1);
@@ -232,14 +231,13 @@ test('getMatching', (t) => {
             "getMatching for 'word' with word boundary prefix match and no language includes all IDs for 'word boundary'"
         );
 
-        // TODO fix...
         // also test longer than 6 chars b/c of prefix cache.
-        // const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', 2);
-        // t.deepEqual(
-        //    getIds(test_all_langs_at_boundary_prefix_8_full),
-        //    [81, 82, 83],
-        //    "getMatching for 'word boundary' with word boundary prefix match and no language includes all IDs for 'word boundary'"
-        // );
+        const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', 2);
+        t.deepEqual(
+            getIds(test_all_langs_at_boundary_prefix_8_full),
+            [81, 82, 83],
+            "getMatching for 'word boundary' with word boundary prefix match and no language includes all IDs for 'word boundary'"
+        );
     });
 
     // t.deepEqual(loader.list('grid'), [ 'else.', 'something', 'test', 'test.' ], 'keys in shard');

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -1,5 +1,6 @@
 'use strict';
 const carmenCache = require('../index.js');
+const scan = carmenCache.PREFIX_SCAN;
 const test = require('tape');
 const fs = require('fs');
 const Grid = require('./grid.js');
@@ -78,7 +79,7 @@ test('getMatching', (t) => {
     const loader = new carmenCache.RocksDBCache('packed', pack);
 
     [cache, loader].forEach((c) => {
-        const test_all_langs_no_prefix = c._getMatching('test', 0);
+        const test_all_langs_no_prefix = c._getMatching('test', scan.disabled);
         t.deepEqual(
             getIds(test_all_langs_no_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43],
@@ -90,7 +91,7 @@ test('getMatching', (t) => {
             "getMatching for 'test' with no prefix match and no language includes only match_language: true"
         );
 
-        const test_all_langs_with_prefix = c._getMatching('test', 1);
+        const test_all_langs_with_prefix = c._getMatching('test', scan.enabled);
         t.deepEqual(
             getIds(test_all_langs_with_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
@@ -102,9 +103,9 @@ test('getMatching', (t) => {
             "getMatching for 'test' with prefix match and no language includes only match_language: true"
         );
 
-        t.false(c._getMatching('te', 0), "getMatching for 'te' with no prefix match returns nothing");
+        t.false(c._getMatching('te', scan.disabled), "getMatching for 'te' with no prefix match returns nothing");
 
-        const te_all_langs_with_prefix = c._getMatching('te', 1);
+        const te_all_langs_with_prefix = c._getMatching('te', scan.enabled);
         t.deepEqual(
             getIds(te_all_langs_with_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53, 61, 62, 63],
@@ -116,7 +117,7 @@ test('getMatching', (t) => {
             "getMatching for 'te' with prefix match and no language includes only match_language: true"
         );
 
-        const test_all_langs_with_prefix_0 = c._getMatching('test', 1, [0]);
+        const test_all_langs_with_prefix_0 = c._getMatching('test', scan.enabled, [0]);
         const test_all_langs_with_prefix_0_matched = getByLanguageMatch(test_all_langs_with_prefix_0, true);
         const test_all_langs_with_prefix_0_unmatched = getByLanguageMatch(test_all_langs_with_prefix_0, false);
         t.deepEqual(
@@ -140,7 +141,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const te_all_langs_with_prefix_0 = c._getMatching('te', 1, [0]);
+        const te_all_langs_with_prefix_0 = c._getMatching('te', scan.enabled, [0]);
         const te_all_langs_with_prefix_0_matched = getByLanguageMatch(te_all_langs_with_prefix_0, true);
         const te_all_langs_with_prefix_0_unmatched = getByLanguageMatch(te_all_langs_with_prefix_0, false);
         t.deepEqual(
@@ -164,7 +165,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const test_all_langs_with_prefix_1 = c._getMatching('test', 1, [1]);
+        const test_all_langs_with_prefix_1 = c._getMatching('test', scan.enabled, [1]);
         const test_all_langs_with_prefix_1_matched = getByLanguageMatch(test_all_langs_with_prefix_1, true);
         const test_all_langs_with_prefix_1_unmatched = getByLanguageMatch(test_all_langs_with_prefix_1, false);
         t.deepEqual(
@@ -188,7 +189,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const test_all_langs_with_prefix_7 = c._getMatching('test', 1, [7]);
+        const test_all_langs_with_prefix_7 = c._getMatching('test', scan.enabled, [7]);
         const test_all_langs_with_prefix_7_matched = getByLanguageMatch(test_all_langs_with_prefix_7, true);
         const test_all_langs_with_prefix_7_unmatched = getByLanguageMatch(test_all_langs_with_prefix_7, false);
         t.deepEqual(
@@ -213,11 +214,11 @@ test('getMatching', (t) => {
         );
 
 
-        t.false(c._getMatching('wor', 0), "getMatching for 'wor' with no prefix match returns nothing");
-        t.false(c._getMatching('word', 0), "getMatching for 'word' with no prefix match returns nothing");
-        t.false(c._getMatching('word boun', 0), "getMatching for 'word bound' with no prefix match returns nothing");
+        t.false(c._getMatching('wor', scan.disabled), "getMatching for 'wor' with no prefix match returns nothing");
+        t.false(c._getMatching('word', scan.disabled), "getMatching for 'word' with no prefix match returns nothing");
+        t.false(c._getMatching('word boun', scan.disabled), "getMatching for 'word bound' with no prefix match returns nothing");
 
-        const test_all_langs_prefix_8 = c._getMatching('wor', 1);
+        const test_all_langs_prefix_8 = c._getMatching('wor', scan.enabled);
         t.deepEqual(
             getIds(test_all_langs_prefix_8),
             [81, 82, 83],
@@ -227,18 +228,18 @@ test('getMatching', (t) => {
         // Extra checks around 3 & 6 char thresholds b/c of prefix cache.
         t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
 
-        const test_all_langs_at_boundary_prefix_8 = c._getMatching('word', 2);
+        const test_all_langs_at_boundary_prefix_8 = c._getMatching('word', scan.word_boundary);
         t.deepEqual(
             getIds(test_all_langs_at_boundary_prefix_8),
             [81, 82, 83],
             "getMatching for 'word' with word boundary prefix match and no language includes all IDs for 'word boundary'"
         );
 
-        t.false(c._getMatching('word b', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+        t.false(c._getMatching('word b', scan.word_boundary), "getMatching for 'wor' with word boundary prefix match returns nothing");
 
-        t.false(c._getMatching('word boun', 2), "getMatching for 'word boun' with word boundary prefix match returns nothing");
+        t.false(c._getMatching('word boun', scan.word_boundary), "getMatching for 'word boun' with word boundary prefix match returns nothing");
 
-        const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', 2);
+        const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', scan.word_boundary);
         t.deepEqual(
             getIds(test_all_langs_at_boundary_prefix_8_full),
             [81, 82, 83],

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -213,9 +213,9 @@ test('getMatching', (t) => {
         );
 
 
+        t.false(c._getMatching('wor', 0), "getMatching for 'wor' with no prefix match returns nothing");
         t.false(c._getMatching('word', 0), "getMatching for 'word' with no prefix match returns nothing");
-        t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
-        t.false(c._getMatching('word boun', 2), "getMatching for 'word boun' with word boundary prefix match returns nothing");
+        t.false(c._getMatching('word boun', 0), "getMatching for 'word bound' with no prefix match returns nothing");
 
         const test_all_langs_prefix_8 = c._getMatching('wor', 1);
         t.deepEqual(
@@ -224,6 +224,9 @@ test('getMatching', (t) => {
             "getMatching for 'wor' with prefix match and no language includes all IDs for 'word boundary'"
         );
 
+        // Extra checks around 3 & 6 char thresholds b/c of prefix cache.
+        t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+
         const test_all_langs_at_boundary_prefix_8 = c._getMatching('word', 2);
         t.deepEqual(
             getIds(test_all_langs_at_boundary_prefix_8),
@@ -231,7 +234,10 @@ test('getMatching', (t) => {
             "getMatching for 'word' with word boundary prefix match and no language includes all IDs for 'word boundary'"
         );
 
-        // also test longer than 6 chars b/c of prefix cache.
+        t.false(c._getMatching('word b', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+
+        t.false(c._getMatching('word boun', 2), "getMatching for 'word boun' with word boundary prefix match returns nothing");
+
         const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', 2);
         t.deepEqual(
             getIds(test_all_langs_at_boundary_prefix_8_full),

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,20 +20,28 @@ abbrev@1:
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
   dependencies:
     acorn "^3.0.4"
 
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^5.2.1, acorn@^5.4.0:
+acorn@^5.2.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+
+acorn@^5.4.0, acorn@^5.5.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+  integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -45,6 +53,7 @@ ajv@^4.9.1:
 ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -52,8 +61,9 @@ ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ansi-escapes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+  integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
 
 ansi-html@^0.0.7:
   version "0.0.7"
@@ -62,18 +72,21 @@ ansi-html@^0.0.7:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-styles@^2.0.1, ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
@@ -98,6 +111,7 @@ are-we-there-yet@~1.1.2:
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -130,12 +144,14 @@ array-iterate@^1.0.0:
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
     array-uniq "^1.0.1"
 
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -148,6 +164,7 @@ array-unique@^0.3.2:
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -178,18 +195,19 @@ atob@^2.0.0:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
 aws-sdk@^2.55.0:
-  version "2.200.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.200.0.tgz#f460c96408725b0eb8c658fddea6e0bfe0ef5a44"
+  version "2.366.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.366.0.tgz#3f2ead3b4efa4537286c6fa14995418ed9d65cbe"
+  integrity sha512-5Nbz2F5uoDl8bNuRoSsZ0Q2Cmzyktmbr4SUq4k1y3S3P9RSCqD9LBR9uzGJKnAdq3Jr0LC/VcL4C4NoOzQPM8A==
   dependencies:
     buffer "4.9.1"
-    events "^1.1.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
     jmespath "0.15.0"
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
     uuid "3.1.0"
-    xml2js "0.4.17"
-    xmlbuilder "4.2.1"
+    xml2js "0.4.19"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -911,10 +929,12 @@ bail@^1.0.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -962,6 +982,7 @@ boom@2.x.x:
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1001,6 +1022,11 @@ buf-compare@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
 
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -1008,6 +1034,7 @@ buffer-shims@^1.0.0:
 buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -1038,12 +1065,14 @@ cache-base@^1.0.1:
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
   dependencies:
     callsites "^0.2.0"
 
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
 
 camelcase@^3.0.0:
   version "3.0.0"
@@ -1060,6 +1089,7 @@ ccount@^1.0.0:
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -1068,12 +1098,13 @@ chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.1.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
   dependencies:
-    ansi-styles "^3.2.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^5.2.0"
+    supports-color "^5.3.0"
 
 character-entities-html4@^1.0.0:
   version "1.1.1"
@@ -1094,6 +1125,7 @@ character-reference-invalid@^1.0.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chokidar@^1.2.0:
   version "1.7.0"
@@ -1110,9 +1142,15 @@ chokidar@^1.2.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+  integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -1126,12 +1164,14 @@ class-utils@^0.3.5:
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -1172,6 +1212,7 @@ cloneable-readable@^1.0.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -1189,14 +1230,16 @@ collection-visit@^1.0.0:
     object-visit "^1.0.0"
 
 color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
-    color-name "^1.1.1"
+    color-name "1.1.3"
 
-color-name@^1.1.1:
+color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -1217,11 +1260,22 @@ component-emitter@^1.2.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -1263,10 +1317,12 @@ core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
@@ -1284,17 +1340,19 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@~2.6.7:
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@~2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
 debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
-    ms "2.0.0"
+    ms "^2.1.1"
 
 decamelize@^1.1.1:
   version "1.2.0"
@@ -1307,6 +1365,12 @@ decode-uri-component@^0.2.0:
 deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -1315,6 +1379,7 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 deep-strict-equal@^0.1.0:
   version "0.1.0"
@@ -1323,11 +1388,11 @@ deep-strict-equal@^0.1.0:
     core-assert "^0.1.0"
 
 define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -1351,18 +1416,6 @@ define-property@^2.0.2:
 defined@^1.0.0, defined@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-
-del@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1416,6 +1469,7 @@ doctrine-temporary-fork@2.0.0-alpha-allowarrayindex:
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
 
@@ -1518,8 +1572,9 @@ error@^7.0.0:
     xtend "~4.0.0"
 
 es-abstract@^1.5.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  integrity sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -1528,16 +1583,18 @@ es-abstract@^1.5.0:
     is-regex "^1.0.4"
 
 es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
   dependencies:
-    is-callable "^1.1.1"
+    is-callable "^1.1.4"
     is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
+    is-symbol "^1.0.2"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 eslint-plugin-node@^5.2.1:
   version "5.2.1"
@@ -1560,8 +1617,9 @@ eslint-plugin-tape@1.1.0:
     pkg-up "^1.0.0"
 
 eslint-scope@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
+  integrity sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -1569,10 +1627,12 @@ eslint-scope@^3.7.1:
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
 eslint@^4.17.0:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.1.tgz#b9138440cb1e98b2f44a0d578c6ecf8eae6150b0"
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  integrity sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -1583,7 +1643,7 @@ eslint@^4.17.0:
     doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.2"
+    espree "^3.5.4"
     esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -1605,23 +1665,33 @@ eslint@^4.17.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^4.0.1"
+    table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.1.3, espree@^3.5.2:
+espree@^3.1.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
   dependencies:
     acorn "^5.4.0"
     acorn-jsx "^3.0.0"
 
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 espurify@^1.5.0:
   version "1.7.0"
@@ -1630,29 +1700,33 @@ espurify@^1.5.0:
     core-js "^2.0.0"
 
 esquery@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
   dependencies:
     estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   dependencies:
     estraverse "^4.1.0"
-    object-assign "^4.0.1"
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-events@^1.1.1:
+events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -1696,8 +1770,9 @@ extend@^3.0.0, extend@~3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 external-editor@^2.0.4:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
@@ -1731,16 +1806,19 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 faye-websocket@~0.10.0:
   version "0.10.0"
@@ -1751,12 +1829,14 @@ faye-websocket@~0.10.0:
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  integrity sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
@@ -1802,19 +1882,21 @@ first-chunk-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
 
 flat-cache@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
+  integrity sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==
   dependencies:
     circular-json "^0.3.1"
-    del "^2.0.2"
     graceful-fs "^4.1.2"
+    rimraf "~2.6.2"
     write "^0.2.1"
 
-for-each@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+for-each@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
-    is-function "~1.0.0"
+    is-callable "^1.1.3"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1825,10 +1907,6 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
-
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1848,9 +1926,17 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+  dependencies:
+    minipass "^2.2.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.0.0:
   version "1.1.3"
@@ -1879,10 +1965,12 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
 function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1987,9 +2075,21 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.2:
+glob@^7.0.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.5, glob@^7.1.2, glob@~7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2003,27 +2103,22 @@ globals-docs@^2.3.0:
   resolved "https://registry.yarnpkg.com/globals-docs/-/globals-docs-2.4.0.tgz#f2c647544eb6161c7c38452808e16e693c2dafbb"
 
 globals@^11.0.1:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249"
+  integrity sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==
 
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-graceful-fs@^4.0.0, graceful-fs@^4.1.2:
+graceful-fs@^4.0.0:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graceful-fs@^4.1.2:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 gulp-sourcemaps@1.6.0:
   version "1.6.0"
@@ -2049,6 +2144,7 @@ har-validator@~4.2.1:
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
 
@@ -2059,6 +2155,12 @@ has-flag@^2.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2091,11 +2193,12 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+has@^1.0.1, has@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
-    function-bind "^1.0.2"
+    function-bind "^1.1.1"
 
 hast-util-is-element@^1.0.0:
   version "1.0.0"
@@ -2171,25 +2274,48 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@^0.4.17:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+iconv-lite@^0.4.17, iconv-lite@^0.4.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.4:
+ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
-ignore@^3.3.3, ignore@^3.3.6:
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  dependencies:
+    minimatch "^3.0.4"
+
+ignore@^3.3.3:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
+ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -2197,6 +2323,7 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.3, ini@~1.3.0:
   version "1.3.5"
@@ -2205,6 +2332,7 @@ ini@^1.3.3, ini@~1.3.0:
 inquirer@^3.0.6:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.0"
@@ -2289,9 +2417,10 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+is-callable@^1.1.3, is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2308,6 +2437,7 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-decimal@^1.0.0:
   version "1.0.1"
@@ -2372,10 +2502,7 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-function@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -2415,22 +2542,6 @@ is-odd@^2.0.0:
   dependencies:
     is-number "^4.0.0"
 
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  dependencies:
-    path-is-inside "^1.0.1"
-
 is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
@@ -2452,10 +2563,12 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
 
@@ -2468,6 +2581,7 @@ is-relative@^1.0.0:
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+  integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
 is-ssh@^1.3.0:
   version "1.3.0"
@@ -2479,9 +2593,12 @@ is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2520,10 +2637,12 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -2542,14 +2661,23 @@ isstream@~0.1.2:
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.8.4, js-yaml@^3.9.1:
+js-yaml@^3.8.4:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.1:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -2569,6 +2697,7 @@ jsesc@~0.5.0:
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -2577,6 +2706,7 @@ json-schema@0.2.3:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -2654,6 +2784,7 @@ lcid@^1.0.0:
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
@@ -2692,9 +2823,14 @@ lodash.isequal@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.11.1, lodash@^4.2.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -2707,8 +2843,9 @@ loose-envify@^1.0.0:
     js-tokens "^3.0.0"
 
 lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -2841,20 +2978,38 @@ mime@^1.3.4:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.1.0, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minipass@^2.2.1, minipass@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
+  integrity sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==
+  dependencies:
+    minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
   version "1.3.1"
@@ -2891,6 +3046,12 @@ module-deps-sortable@4.0.6:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 multimatch@^2.1.0:
   version "2.1.0"
@@ -2904,10 +3065,16 @@ multimatch@^2.1.0:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.3.0, nan@~2.5.1:
+nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+
+nan@~2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -2929,8 +3096,18 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-pre-gyp@^0.6.39, node-pre-gyp@~0.6.32:
+needle@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -2945,6 +3122,22 @@ node-pre-gyp@^0.6.39, node-pre-gyp@~0.6.32:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
+
+node-pre-gyp@~0.10.1:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -2967,6 +3160,19 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-bundled@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
+  integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
+
+npm-packlist@^1.1.6:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
+  integrity sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -2997,13 +3203,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+object-inspect@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
 
-object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -3027,18 +3235,21 @@ object.pick@^1.3.0:
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
 
 optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
   dependencies:
     deep-is "~0.1.3"
     fast-levenshtein "~2.0.4"
@@ -3165,14 +3376,17 @@ path-exists@^3.0.0:
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
 path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-platform@~0.11.15:
   version "0.11.15"
@@ -3209,6 +3423,7 @@ performance-now@^0.2.0:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
 pify@^3.0.0:
   version "3.0.0"
@@ -3217,12 +3432,14 @@ pify@^3.0.0:
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
   dependencies:
     pinkie "^2.0.0"
 
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 pkg-up@^1.0.0:
   version "1.0.0"
@@ -3233,6 +3450,7 @@ pkg-up@^1.0.0:
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+  integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -3241,6 +3459,7 @@ posix-character-classes@^0.1.0:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -3257,10 +3476,12 @@ process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
 progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
 property-information@^3.1.0:
   version "3.2.0"
@@ -3270,17 +3491,15 @@ protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.6.tgz#f8bb263ea1b5fd7a7604d26b8be39bd77678bf8a"
 
-protozero@~1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/protozero/-/protozero-1.5.1.tgz#5a27df6fb6e1ed743f510812ae76c082f5b16638"
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -3297,6 +3516,7 @@ qs@~6.4.0:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -3317,6 +3537,16 @@ rc@^1.1.7:
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
   dependencies:
     deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -3360,7 +3590,7 @@ read-pkg@^2.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
   dependencies:
@@ -3370,6 +3600,19 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.2.2:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readable-stream@~2.0.0:
@@ -3438,6 +3681,11 @@ regex-not@^1.0.0:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+  integrity sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -3598,6 +3846,7 @@ require-main-filename@^1.0.1:
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
@@ -3605,6 +3854,7 @@ require-uncached@^1.0.3:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -3614,15 +3864,23 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.6, resolve@^1.3.3, resolve@~1.5.0:
+resolve@^1.1.3, resolve@^1.1.6, resolve@^1.3.3:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@~1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  integrity sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==
   dependencies:
     path-parse "^1.0.5"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
@@ -3630,6 +3888,7 @@ restore-cursor@^2.0.0:
 resumer@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  integrity sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=
   dependencies:
     through "~2.3.4"
 
@@ -3637,7 +3896,7 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -3646,22 +3905,30 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
   dependencies:
     rx-lite "*"
 
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-json-parse@~1.0.1:
   version "1.0.1"
@@ -3673,21 +3940,33 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
-sax@>=0.6.0:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.3.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3724,12 +4003,14 @@ set-value@^2.0.0:
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shelljs@^0.7.5:
   version "0.7.8"
@@ -3750,6 +4031,7 @@ slash@^1.0.0:
 slice-ansi@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  integrity sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
@@ -3839,6 +4121,7 @@ split-string@^3.0.1, split-string@^3.0.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
   version "1.13.1"
@@ -3897,6 +4180,7 @@ string-width@^1.0.0, string-width@^1.0.1, string-width@^1.0.2:
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
@@ -3904,6 +4188,7 @@ string-width@^2.1.0, string-width@^2.1.1:
 string.prototype.trim@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
@@ -3916,6 +4201,14 @@ string_decoder@0.10, string_decoder@~0.10.x:
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -3941,6 +4234,7 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
 
@@ -3964,6 +4258,7 @@ strip-bom@^3.0.0:
 strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 subarg@^1.0.0:
   version "1.0.0"
@@ -3974,6 +4269,7 @@ subarg@^1.0.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^4.1.0:
   version "4.5.0"
@@ -3981,15 +4277,17 @@ supports-color@^4.1.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
-table@^4.0.1:
+table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  integrity sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==
   dependencies:
     ajv "^5.2.3"
     ajv-keywords "^2.1.0"
@@ -3999,19 +4297,20 @@ table@^4.0.1:
     string-width "^2.1.1"
 
 tape@^4.6.3:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.9.0.tgz#855c08360395133709d34d3fbf9ef341eb73ca6a"
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.9.1.tgz#1173d7337e040c76fbf42ec86fcabedc9b3805c9"
+  integrity sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==
   dependencies:
     deep-equal "~1.0.1"
     defined "~1.0.0"
-    for-each "~0.3.2"
+    for-each "~0.3.3"
     function-bind "~1.1.1"
     glob "~7.1.2"
-    has "~1.0.1"
+    has "~1.0.3"
     inherits "~2.0.3"
     minimist "~1.2.0"
-    object-inspect "~1.5.0"
-    resolve "~1.5.0"
+    object-inspect "~1.6.0"
+    resolve "~1.7.1"
     resumer "~0.0.0"
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
@@ -4037,9 +4336,23 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tar@^4:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 through2-filter@^2.0.0:
   version "2.0.0"
@@ -4080,6 +4393,7 @@ tiny-lr@^1.0.3:
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
 
@@ -4153,6 +4467,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
 
@@ -4257,6 +4572,7 @@ urix@^0.1.0:
 url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -4272,10 +4588,12 @@ use@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 uuid@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+  integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
 uuid@^3.0.0:
   version "3.2.1"
@@ -4394,8 +4712,9 @@ which-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
 which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
@@ -4408,6 +4727,7 @@ wide-align@^1.1.0:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -4419,10 +4739,12 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  integrity sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=
   dependencies:
     mkdirp "^0.5.1"
 
@@ -4434,18 +4756,18 @@ x-is-string@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
 
-xml2js@0.4.17:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "^4.1.0"
+    xmlbuilder "~9.0.1"
 
-xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
-  dependencies:
-    lodash "^4.0.0"
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
@@ -4458,6 +4780,12 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
Get carmen-cache to respect tokenized words & not attempt to complete them for you. See https://github.com/mapbox/carmen/pull/795

Current status; mostly functional. Outstanding tasks;

- [x] Could use a preliminary review
- [x] Depends on rockdb update https://github.com/mapbox/carmen-cache/pull/136
- [x] As currently written this would be a breaking API change. May be worth making it backwards compatible. Input is welcome here...
- [x] Need to at slightly stricter validation of prefix match setup (must be 0,1,2)
- [ ] Add CHANGELOG entry... oh gawd, there is no change log...
- [ ] Regenerate Docs