### PR TITLE
Word boundary scan

### DIFF
--- a/API.md
+++ b/API.md
@@ -79,7 +79,7 @@ slightly in specific field names and types.
 
 -   `phrase` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The matched string
 -   `weight` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** A float between 0 and 1 representing how much of the query this string covers
--   `prefix` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether or not to do a prefix scan (as opposed to an exact match scan); used for autocomplete
+-   `prefix` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** whether or do an exact match (0), prefix scan(1), or word boundary scan(2); used for autocomplete
 -   `idx` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** an identifier of the index the match came from; opaque to carmen-cache but returned in results
 -   `zoom` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the configured tile zoom level for the index
 -   `mask` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** a bitmask representing which tokens in the original query the subquery covers
@@ -142,7 +142,7 @@ Retrieves data exactly matching phrase and language settings by id
 **Parameters**
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `matches_prefixes` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** : T if it matches exactly, F: if it does not
+-   `matches_prefixes` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** whether or do an exact match (0), prefix scan(1), or word boundary scan(2); used for autocomplete
 -   `optional` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** ; array of languages
 
 **Examples**
@@ -185,7 +185,7 @@ and with a relevance penalty applied to languages that don't match those request
 **Parameters**
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `matches_prefixes` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** : T if it matches exactly, F: if it does not
+-   `matches_prefixes` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** whether or do an exact match (0), prefix scan(1), or word boundary scan(2); used for autocomplete
 -   `optional` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** ; array of languages
 
 **Examples**
@@ -368,7 +368,7 @@ Retrieves data exactly matching phrase and language settings by id
 **Parameters**
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `matches_prefixes` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** : T if it matches exactly, F: if it does not
+-   `matches_prefixes` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** whether or do an exact match (0), prefix scan(1), or word boundary scan(2); used for autocomplete
 -   `optional` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** ; array of languages
 
 **Examples**
@@ -390,7 +390,7 @@ Retrieves grid that at least partially matches phrase and/or language inputs
 **Parameters**
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `matches_prefixes` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** : T if it matches exactly, F: if it does not
+-   `matches_prefixes` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** whether or do an exact match (0), prefix scan(1), or word boundary scan(2); used for autocomplete
 -   `optional` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** ; array of languages
 
 **Examples**

--- a/bench/coalesce.bench.test.js
+++ b/bench/coalesce.bench.test.js
@@ -14,7 +14,7 @@ const test = require('tape');
         zoom: 14,
         weight: 1,
         phrase: '3848571113',
-        prefix: false,
+        prefix: 0,
         mask: 1 << 0
     }];
     test('coalesceSingle', (t) => {
@@ -84,7 +84,7 @@ const test = require('tape');
         zoom: 12,
         weight: 0.25,
         phrase: '1965155344',
-        prefix: false
+        prefix: 0
     }, {
         cache: b,
         mask: 1 << 1,
@@ -92,7 +92,7 @@ const test = require('tape');
         zoom: 14,
         weight: 0.75,
         phrase: '3848571113',
-        prefix: false
+        prefix: 0
     }];
     test('coalesceMulti', (t) => {
         const time = +new Date;

--- a/index.js
+++ b/index.js
@@ -1,2 +1,8 @@
 'use strict';
 exports = module.exports = require('./lib/carmen.node');
+
+exports.PREFIX_SCAN = {
+    disabled: 0,
+    enabled: 1,
+    word_boundary: 2
+};

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -307,7 +307,7 @@ NAN_METHOD(JSCache<T>::_getmatching) {
         return Nan::ThrowTypeError("first arg must be a String");
     }
     if (!info[1]->IsNumber()) {
-        return Nan::ThrowTypeError("second arg must be a integer between 0 - 2");
+        return Nan::ThrowTypeError("second arg must be an integer between 0 - 2");
     }
     try {
         Nan::Utf8String utf8_id(info[0]);
@@ -318,14 +318,14 @@ NAN_METHOD(JSCache<T>::_getmatching) {
 
         int32_t int32_prefix = info[1]->Int32Value();
         if (int32_prefix < 0 || int32_prefix > 2) {
-            return Nan::ThrowTypeError("prefix value must be a integer between 0 - 2");
+            return Nan::ThrowTypeError("second arg must be an integer between 0 - 2");
         }
         PrefixMatch match_prefixes = static_cast<PrefixMatch>(int32_prefix);
 
         langfield_type langfield;
         if (info.Length() > 2 && !(info[2]->IsNull() || info[2]->IsUndefined())) {
             if (!info[2]->IsArray()) {
-                return Nan::ThrowTypeError("third arg, if supplied must be an Array");
+                return Nan::ThrowTypeError("third arg, if supplied, must be an Array");
             }
             langfield = langarrayToLangfield(Local<Array>::Cast(info[2]));
         } else {

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -43,6 +43,12 @@ class noncopyable {
     noncopyable& operator=(noncopyable const&) = delete;
 };
 
+typedef enum {
+    disabled,
+    enabled,
+    word_boundary
+} PrefixMatch;
+
 typedef unsigned __int128 langfield_type;
 constexpr uint64_t LANGUAGE_MATCH_BOOST = static_cast<const uint64_t>(1) << 63;
 
@@ -70,7 +76,7 @@ struct PhrasematchSubq {
                     char t,
                     double w,
                     std::string p,
-                    bool pf,
+                    PrefixMatch pf,
                     unsigned short i,
                     unsigned short z,
                     uint32_t m,
@@ -87,7 +93,7 @@ struct PhrasematchSubq {
     char type;
     double weight;
     std::string phrase;
-    bool prefix;
+    PrefixMatch prefix;
     unsigned short idx;
     unsigned short zoom;
     uint32_t mask;

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -18,11 +18,11 @@ intarray MemoryCache::__get(const std::string& phrase, langfield_type langfield)
     return array;
 }
 
-intarray MemoryCache::__getmatching(const std::string& phrase_ref, bool match_prefixes, langfield_type langfield) {
+intarray MemoryCache::__getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield) {
     intarray array;
     std::string phrase = phrase_ref;
 
-    if (!match_prefixes) phrase.push_back(LANGFIELD_SEPARATOR);
+    if (match_prefixes == PrefixMatch::disabled) phrase.push_back(LANGFIELD_SEPARATOR);
     size_t phrase_length = phrase.length();
     const char* phrase_data = phrase.data();
     // Load values from memory cache
@@ -34,6 +34,12 @@ intarray MemoryCache::__getmatching(const std::string& phrase_ref, bool match_pr
         if (item_length < phrase_length) continue;
 
         if (memcmp(phrase_data, item_data, phrase_length) == 0) {
+            if (match_prefixes == PrefixMatch::word_boundary) {
+                size_t end = phrase_length;
+                if (item_data[end] != LANGFIELD_SEPARATOR && item_data[end] != ' ') {
+                    continue;
+                }
+            }
             langfield_type message_langfield = extract_langfield(item.first);
 
             if ((message_langfield & langfield) != 0u) {

--- a/src/memorycache.hpp
+++ b/src/memorycache.hpp
@@ -16,10 +16,10 @@ class MemoryCache {
     void _set(std::string key_id, std::vector<uint64_t>, langfield_type langfield, bool append);
 
     std::vector<uint64_t> _get(std::string& phrase, std::vector<uint64_t> languages);
-    std::vector<uint64_t> _getmatching(std::string phrase, bool match_prefixes, std::vector<uint64_t> languages);
+    std::vector<uint64_t> _getmatching(std::string phrase, PrefixMatch match_prefixes, std::vector<uint64_t> languages);
 
     std::vector<uint64_t> __get(const std::string& phrase, langfield_type langfield);
-    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, bool match_prefixes, langfield_type langfield);
+    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield);
 
     arraycache cache_;
 };

--- a/src/rocksdbcache.hpp
+++ b/src/rocksdbcache.hpp
@@ -76,7 +76,7 @@ class RocksDBCache {
     std::vector<std::pair<std::string, langfield_type>> list();
 
     std::vector<uint64_t> __get(const std::string& phrase, langfield_type langfield);
-    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, bool match_prefixes, langfield_type langfield);
+    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield);
 
     std::shared_ptr<rocksdb::DB> db;
 };

--- a/test/coalesce.proximity.test.js
+++ b/test/coalesce.proximity.test.js
@@ -7,6 +7,7 @@
 const MemoryCache = require('../index.js').MemoryCache;
 const Grid = require('./grid.js');
 const coalesce = require('../index.js').coalesce;
+const scan = require('../index.js').PREFIX_SCAN;
 const test = require('tape');
 
 (function() {
@@ -56,7 +57,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 + 15]
@@ -76,7 +77,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 - 15]
@@ -96,7 +97,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 - 15]
@@ -116,7 +117,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: 0
+            prefix: scan.disabled
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 + 15]

--- a/test/coalesce.proximity.test.js
+++ b/test/coalesce.proximity.test.js
@@ -56,7 +56,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 + 15]
@@ -76,7 +76,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 + 10, 100 - 15]
@@ -96,7 +96,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 - 15]
@@ -116,7 +116,7 @@ const test = require('tape');
             zoom: 14,
             weight: 1,
             phrase: '1',
-            prefix: false
+            prefix: 0
         }], {
             radius: 200,
             centerzxy: [14, 100 - 10, 100 + 15]

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -3,6 +3,7 @@ const MemoryCache = require('../index.js').MemoryCache;
 const RocksDBCache = require('../index.js').RocksDBCache;
 const Grid = require('./grid.js');
 const coalesce = require('../index.js').coalesce;
+const scan = require('../index.js').PREFIX_SCAN;
 const test = require('tape');
 const fs = require('fs');
 
@@ -61,7 +62,7 @@ test('coalesce args', (t) => {
         zoom: 2,
         weight: 1,
         phrase: 'a',
-        prefix: 0
+        prefix: scan.disabled
     };
 
     t.throws(() => {
@@ -304,7 +305,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '0.relev');
@@ -324,7 +325,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [3,3,3]
             }, (err, res) => {
@@ -346,7 +347,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [2, 1, 1, 1, 1]
             }, (err, res) => {
@@ -393,7 +394,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.ok(res, 'got back a result');
@@ -433,7 +434,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'got back 2 results');
@@ -488,7 +489,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 4, 'got back 4 results');
@@ -511,7 +512,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -535,7 +536,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -611,7 +612,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -619,7 +620,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -640,7 +641,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -648,7 +649,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [2,3,3]
             }, (err, res) => {
@@ -711,7 +712,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -719,7 +720,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -740,7 +741,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -748,7 +749,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -771,7 +772,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -779,7 +780,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0,
+                prefix: scan.disabled,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -840,7 +841,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -848,7 +849,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [14,4601,6200]
             }, (err, res) => {
@@ -867,7 +868,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -875,7 +876,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 centerzxy: [14,4610,6200]
             }, (err, res) => {
@@ -933,7 +934,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -941,7 +942,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -1027,7 +1028,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1035,7 +1036,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1052,7 +1053,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1060,7 +1061,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [2, 0, 0, 1, 3]
             }, (err, res) => {
@@ -1077,7 +1078,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1085,7 +1086,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [6, 14, 30, 15, 64]
             }, (err, res) => {
@@ -1102,7 +1103,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: c,
                 mask: 1 << 0,
@@ -1110,7 +1111,7 @@ test('coalesce args', (t) => {
                 zoom: 5,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1173,7 +1174,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1181,7 +1182,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1239,7 +1240,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1247,7 +1248,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1311,7 +1312,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1319,7 +1320,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1327,7 +1328,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');
@@ -1345,7 +1346,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1353,7 +1354,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1361,7 +1362,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: 0
+                prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -61,7 +61,7 @@ test('coalesce args', (t) => {
         zoom: 2,
         weight: 1,
         phrase: 'a',
-        prefix: false
+        prefix: 0
     };
 
     t.throws(() => {
@@ -133,7 +133,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             },
             {
                 cache: new MemoryCache('b'),
@@ -142,7 +142,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }
         ];
 
@@ -205,48 +205,61 @@ test('coalesce args', (t) => {
     }, /Arg 3 must be a callback/, 'throws');
 
     t.throws(() => {
-        coalesce([{ mask: 1 << 0, idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ mask: 1 << 0, idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5, prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, zoom: 1, weight: .5, prefix: 0 }],{},() => {});
     }, /missing/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: '', mask: 1 << 0, idx: 1, weight: .5,  zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: '', mask: 1 << 0, idx: 1, weight: .5,  zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /cache value must be a Cache object/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: '', idx: 1, zoom: 1, weight: .5, phrase: '1', prefix: 0 }],{},() => {});
     }, /mask value must be a number/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: '', weight: .5, zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /idx value must be a number/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: '', phrase: '1', prefix: 0 }],{},() => {});
     }, /zoom value must be a number/, 'throws');
 
     t.throws(() => {
-        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: '1', prefix: false }],{},() => {});
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: '', zoom: 1, phrase: '1', prefix: 0 }],{},() => {});
     }, /weight value must be a number/, 'throws');
+
+    t.throws(() => {
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: 0.5, zoom: 1, phrase: '1', prefix: false }],{},() => {});
+    }, /prefix value must be a integer between 0 - 2/, 'throws');
+
+    t.throws(() => {
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: 0.5, zoom: 1, phrase: '1', prefix: 3 }],{},() => {});
+    }, /prefix value must be a integer between 0 - 2/, 'throws on 3');
+
+    t.throws(() => {
+        coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: 0.5, zoom: 1, phrase: '1', prefix: -1 }],{},() => {});
+    }, /prefix value must be a integer between 0 - 2/, 'throws on 3');
+
 
     t.throws(() => {
         coalesce([{ cache: new MemoryCache('b'), mask: 1 << 0, idx: 1, weight: .5, zoom: 1, phrase: '' }],{},() => {});
@@ -291,7 +304,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '0.relev');
@@ -311,7 +324,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [3,3,3]
             }, (err, res) => {
@@ -333,7 +346,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [2, 1, 1, 1, 1]
             }, (err, res) => {
@@ -380,7 +393,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.ok(res, 'got back a result');
@@ -420,7 +433,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'got back 2 results');
@@ -475,7 +488,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 4, 'got back 4 results');
@@ -498,7 +511,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -522,7 +535,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 1,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -598,7 +611,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -606,7 +619,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -627,7 +640,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -635,7 +648,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [2,3,3]
             }, (err, res) => {
@@ -698,7 +711,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -706,7 +719,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -727,7 +740,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -735,7 +748,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [0]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -758,7 +771,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -766,7 +779,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false,
+                prefix: 0,
                 languages: [3]
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
@@ -827,7 +840,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -835,7 +848,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [14,4601,6200]
             }, (err, res) => {
@@ -854,7 +867,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -862,7 +875,7 @@ test('coalesce args', (t) => {
                 zoom: 14,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 centerzxy: [14,4610,6200]
             }, (err, res) => {
@@ -920,7 +933,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -928,7 +941,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
@@ -1014,7 +1027,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1022,7 +1035,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1039,7 +1052,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1047,7 +1060,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [2, 0, 0, 1, 3]
             }, (err, res) => {
@@ -1064,7 +1077,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1072,7 +1085,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [6, 14, 30, 15, 64]
             }, (err, res) => {
@@ -1089,7 +1102,7 @@ test('coalesce args', (t) => {
                 zoom: 2,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: c,
                 mask: 1 << 0,
@@ -1097,7 +1110,7 @@ test('coalesce args', (t) => {
                 zoom: 5,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {
                 bboxzxy: [1, 0, 0, 1, 0]
             }, (err, res) => {
@@ -1160,7 +1173,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1168,7 +1181,7 @@ test('coalesce args', (t) => {
                 zoom: 1,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1226,7 +1239,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1234,7 +1247,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.5,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 2, 'res length = 2');
@@ -1298,7 +1311,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1306,7 +1319,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1314,7 +1327,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');
@@ -1332,7 +1345,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: b,
                 mask: 1 << 0,
@@ -1340,7 +1353,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }, {
                 cache: c,
                 mask: 1 << 1,
@@ -1348,7 +1361,7 @@ test('coalesce args', (t) => {
                 zoom: 0,
                 weight: 0.33,
                 phrase: '1',
-                prefix: false
+                prefix: 0
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.equal(res.length, 1, 'res length = 1');

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -1,5 +1,6 @@
 'use strict';
 const carmenCache = require('../index.js');
+const scan = carmenCache.PREFIX_SCAN;
 const test = require('tape');
 const fs = require('fs');
 const Grid = require('./grid.js');
@@ -78,7 +79,7 @@ test('getMatching', (t) => {
     const loader = new carmenCache.RocksDBCache('packed', pack);
 
     [cache, loader].forEach((c) => {
-        const test_all_langs_no_prefix = c._getMatching('test', 0);
+        const test_all_langs_no_prefix = c._getMatching('test', scan.disabled);
         t.deepEqual(
             getIds(test_all_langs_no_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43],
@@ -90,7 +91,7 @@ test('getMatching', (t) => {
             "getMatching for 'test' with no prefix match and no language includes only match_language: true"
         );
 
-        const test_all_langs_with_prefix = c._getMatching('test', 1);
+        const test_all_langs_with_prefix = c._getMatching('test', scan.enabled);
         t.deepEqual(
             getIds(test_all_langs_with_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
@@ -102,9 +103,9 @@ test('getMatching', (t) => {
             "getMatching for 'test' with prefix match and no language includes only match_language: true"
         );
 
-        t.false(c._getMatching('te', 0), "getMatching for 'te' with no prefix match returns nothing");
+        t.false(c._getMatching('te', scan.disabled), "getMatching for 'te' with no prefix match returns nothing");
 
-        const te_all_langs_with_prefix = c._getMatching('te', 1);
+        const te_all_langs_with_prefix = c._getMatching('te', scan.enabled);
         t.deepEqual(
             getIds(te_all_langs_with_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53, 61, 62, 63],
@@ -116,7 +117,7 @@ test('getMatching', (t) => {
             "getMatching for 'te' with prefix match and no language includes only match_language: true"
         );
 
-        const test_all_langs_with_prefix_0 = c._getMatching('test', 1, [0]);
+        const test_all_langs_with_prefix_0 = c._getMatching('test', scan.enabled, [0]);
         const test_all_langs_with_prefix_0_matched = getByLanguageMatch(test_all_langs_with_prefix_0, true);
         const test_all_langs_with_prefix_0_unmatched = getByLanguageMatch(test_all_langs_with_prefix_0, false);
         t.deepEqual(
@@ -140,7 +141,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const te_all_langs_with_prefix_0 = c._getMatching('te', 1, [0]);
+        const te_all_langs_with_prefix_0 = c._getMatching('te', scan.enabled, [0]);
         const te_all_langs_with_prefix_0_matched = getByLanguageMatch(te_all_langs_with_prefix_0, true);
         const te_all_langs_with_prefix_0_unmatched = getByLanguageMatch(te_all_langs_with_prefix_0, false);
         t.deepEqual(
@@ -164,7 +165,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const test_all_langs_with_prefix_1 = c._getMatching('test', 1, [1]);
+        const test_all_langs_with_prefix_1 = c._getMatching('test', scan.enabled, [1]);
         const test_all_langs_with_prefix_1_matched = getByLanguageMatch(test_all_langs_with_prefix_1, true);
         const test_all_langs_with_prefix_1_unmatched = getByLanguageMatch(test_all_langs_with_prefix_1, false);
         t.deepEqual(
@@ -188,7 +189,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const test_all_langs_with_prefix_7 = c._getMatching('test', 1, [7]);
+        const test_all_langs_with_prefix_7 = c._getMatching('test', scan.enabled, [7]);
         const test_all_langs_with_prefix_7_matched = getByLanguageMatch(test_all_langs_with_prefix_7, true);
         const test_all_langs_with_prefix_7_unmatched = getByLanguageMatch(test_all_langs_with_prefix_7, false);
         t.deepEqual(
@@ -213,11 +214,11 @@ test('getMatching', (t) => {
         );
 
 
-        t.false(c._getMatching('wor', 0), "getMatching for 'wor' with no prefix match returns nothing");
-        t.false(c._getMatching('word', 0), "getMatching for 'word' with no prefix match returns nothing");
-        t.false(c._getMatching('word boun', 0), "getMatching for 'word bound' with no prefix match returns nothing");
+        t.false(c._getMatching('wor', scan.disabled), "getMatching for 'wor' with no prefix match returns nothing");
+        t.false(c._getMatching('word', scan.disabled), "getMatching for 'word' with no prefix match returns nothing");
+        t.false(c._getMatching('word boun', scan.disabled), "getMatching for 'word bound' with no prefix match returns nothing");
 
-        const test_all_langs_prefix_8 = c._getMatching('wor', 1);
+        const test_all_langs_prefix_8 = c._getMatching('wor', scan.enabled);
         t.deepEqual(
             getIds(test_all_langs_prefix_8),
             [81, 82, 83],
@@ -227,18 +228,18 @@ test('getMatching', (t) => {
         // Extra checks around 3 & 6 char thresholds b/c of prefix cache.
         t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
 
-        const test_all_langs_at_boundary_prefix_8 = c._getMatching('word', 2);
+        const test_all_langs_at_boundary_prefix_8 = c._getMatching('word', scan.word_boundary);
         t.deepEqual(
             getIds(test_all_langs_at_boundary_prefix_8),
             [81, 82, 83],
             "getMatching for 'word' with word boundary prefix match and no language includes all IDs for 'word boundary'"
         );
 
-        t.false(c._getMatching('word b', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+        t.false(c._getMatching('word b', scan.word_boundary), "getMatching for 'wor' with word boundary prefix match returns nothing");
 
-        t.false(c._getMatching('word boun', 2), "getMatching for 'word boun' with word boundary prefix match returns nothing");
+        t.false(c._getMatching('word boun', scan.word_boundary), "getMatching for 'word boun' with word boundary prefix match returns nothing");
 
-        const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', 2);
+        const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', scan.word_boundary);
         t.deepEqual(
             getIds(test_all_langs_at_boundary_prefix_8_full),
             [81, 82, 83],

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -21,6 +21,33 @@ const getByLanguageMatch = function(grids, match) {
     return grids.filter((x) => { return x.matches_language === match; });
 };
 
+test('getMatching args', (t) => {
+    const c = new carmenCache.MemoryCache('mem');
+
+    t.throws(() => {
+        c._getMatching();
+    }, /expected two or three info: id, match_prefixes, \[languages\]/, 'require args');
+
+    t.throws(() => {
+        c._getMatching(false, false);
+    }, /first arg must be a String/, 'require string as first arg');
+
+    t.throws(() => {
+        c._getMatching('1', false);
+    }, /second arg must be an integer between 0 - 2/, 'require number as second args');
+
+    t.throws(() => {
+        c._getMatching('1', 3);
+    }, /second arg must be an integer between 0 - 2/, 'require integer between 0-2 as second arg');
+
+
+    t.throws(() => {
+        c._getMatching('1', 0, false);
+    }, /third arg, if supplied, must be an Array/, 'require array as third arg');
+
+    t.end();
+});
+
 test('getMatching', (t) => {
     const cache = new carmenCache.MemoryCache('mem');
 

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -66,13 +66,19 @@ test('getMatching', (t) => {
         Grid.encode({ id: 73, x: 1, y: 1, relev: 1, score: 1 })
     ], [0]);
 
+    cache._set('word boundary', [
+        Grid.encode({ id: 81, x: 1, y: 1, relev: 1, score: 1 }),
+        Grid.encode({ id: 82, x: 1, y: 1, relev: 1, score: 1 }),
+        Grid.encode({ id: 83, x: 1, y: 1, relev: 1, score: 1 })
+    ], [0]);
+
     // cache A serializes data, cache B loads serialized data.
     const pack = tmpfile();
     cache.pack(pack);
     const loader = new carmenCache.RocksDBCache('packed', pack);
 
     [cache, loader].forEach((c) => {
-        const test_all_langs_no_prefix = c._getMatching('test', false);
+        const test_all_langs_no_prefix = c._getMatching('test', 0);
         t.deepEqual(
             getIds(test_all_langs_no_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43],
@@ -84,7 +90,7 @@ test('getMatching', (t) => {
             "getMatching for 'test' with no prefix match and no language includes only match_language: true"
         );
 
-        const test_all_langs_with_prefix = c._getMatching('test', true);
+        const test_all_langs_with_prefix = c._getMatching('test', 1);
         t.deepEqual(
             getIds(test_all_langs_with_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53],
@@ -96,9 +102,9 @@ test('getMatching', (t) => {
             "getMatching for 'test' with prefix match and no language includes only match_language: true"
         );
 
-        t.false(c._getMatching('te', false), "getMatching for 'te' with no prefix match returns nothing");
+        t.false(c._getMatching('te', 0), "getMatching for 'te' with no prefix match returns nothing");
 
-        const te_all_langs_with_prefix = c._getMatching('te', true);
+        const te_all_langs_with_prefix = c._getMatching('te', 1);
         t.deepEqual(
             getIds(te_all_langs_with_prefix),
             [1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 42, 43, 51, 52, 53, 61, 62, 63],
@@ -110,7 +116,7 @@ test('getMatching', (t) => {
             "getMatching for 'te' with prefix match and no language includes only match_language: true"
         );
 
-        const test_all_langs_with_prefix_0 = c._getMatching('test', true, [0]);
+        const test_all_langs_with_prefix_0 = c._getMatching('test', 1, [0]);
         const test_all_langs_with_prefix_0_matched = getByLanguageMatch(test_all_langs_with_prefix_0, true);
         const test_all_langs_with_prefix_0_unmatched = getByLanguageMatch(test_all_langs_with_prefix_0, false);
         t.deepEqual(
@@ -134,7 +140,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const te_all_langs_with_prefix_0 = c._getMatching('te', true, [0]);
+        const te_all_langs_with_prefix_0 = c._getMatching('te', 1, [0]);
         const te_all_langs_with_prefix_0_matched = getByLanguageMatch(te_all_langs_with_prefix_0, true);
         const te_all_langs_with_prefix_0_unmatched = getByLanguageMatch(te_all_langs_with_prefix_0, false);
         t.deepEqual(
@@ -158,7 +164,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const test_all_langs_with_prefix_1 = c._getMatching('test', true, [1]);
+        const test_all_langs_with_prefix_1 = c._getMatching('test', 1, [1]);
         const test_all_langs_with_prefix_1_matched = getByLanguageMatch(test_all_langs_with_prefix_1, true);
         const test_all_langs_with_prefix_1_unmatched = getByLanguageMatch(test_all_langs_with_prefix_1, false);
         t.deepEqual(
@@ -182,7 +188,7 @@ test('getMatching', (t) => {
             'all the language-matching results come first'
         );
 
-        const test_all_langs_with_prefix_7 = c._getMatching('test', true, [7]);
+        const test_all_langs_with_prefix_7 = c._getMatching('test', 1, [7]);
         const test_all_langs_with_prefix_7_matched = getByLanguageMatch(test_all_langs_with_prefix_7, true);
         const test_all_langs_with_prefix_7_unmatched = getByLanguageMatch(test_all_langs_with_prefix_7, false);
         t.deepEqual(
@@ -204,6 +210,39 @@ test('getMatching', (t) => {
             getIds(test_all_langs_with_prefix_7.slice(0, test_all_langs_with_prefix_7_matched.length)),
             getIds(test_all_langs_with_prefix_7_matched),
             'all the language-matching results come first'
+        );
+
+
+        t.false(c._getMatching('wor', 0), "getMatching for 'wor' with no prefix match returns nothing");
+        t.false(c._getMatching('word', 0), "getMatching for 'word' with no prefix match returns nothing");
+        t.false(c._getMatching('word boun', 0), "getMatching for 'word bound' with no prefix match returns nothing");
+
+        const test_all_langs_prefix_8 = c._getMatching('wor', 1);
+        t.deepEqual(
+            getIds(test_all_langs_prefix_8),
+            [81, 82, 83],
+            "getMatching for 'wor' with prefix match and no language includes all IDs for 'word boundary'"
+        );
+
+        // Extra checks around 3 & 6 char thresholds b/c of prefix cache.
+        t.false(c._getMatching('wor', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+
+        const test_all_langs_at_boundary_prefix_8 = c._getMatching('word', 2);
+        t.deepEqual(
+            getIds(test_all_langs_at_boundary_prefix_8),
+            [81, 82, 83],
+            "getMatching for 'word' with word boundary prefix match and no language includes all IDs for 'word boundary'"
+        );
+
+        t.false(c._getMatching('word b', 2), "getMatching for 'wor' with word boundary prefix match returns nothing");
+
+        t.false(c._getMatching('word boun', 2), "getMatching for 'word boun' with word boundary prefix match returns nothing");
+
+        const test_all_langs_at_boundary_prefix_8_full = c._getMatching('word boundary', 2);
+        t.deepEqual(
+            getIds(test_all_langs_at_boundary_prefix_8_full),
+            [81, 82, 83],
+            "getMatching for 'word boundary' with word boundary prefix match and no language includes all IDs for 'word boundary'"
         );
     });
 


### PR DESCRIPTION
Get carmen-cache to respect tokenized words & not attempt to complete them for you. See https://github.com/mapbox/carmen/pull/795

This PR is a replacement for https://github.com/mapbox/carmen-cache/pull/137 after rebasing on the 0.22.0 refactor.

Current status; functional. Outstanding tasks;

- [ ] Add CHANGELOG
- [x] Regenerate Docs(?)