### PR TITLE
Update scoredist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ matrix:
         - mason link llvm-cov ${MASON_LLVM_RELEASE}
         - which llvm-cov
         - curl -S -f https://codecov.io/bash -o codecov
+        - curl -S -f https://raw.githubusercontent.com/codecov/codecov-bash/0b376529f626b50b7d4a9fb734e0e50d28b9b91e/codecov -o codecov
         - chmod +x codecov
         - ./codecov -x "llvm-cov gcov" -Z
     # Clang format build

--- a/bench/coalesce.bench.test.js
+++ b/bench/coalesce.bench.test.js
@@ -55,7 +55,7 @@ const test = require('tape');
             }
             coalesce(stacks, { centerzxy: [14,4893,6001] }, (err, res) => {
                 let checks = true;
-                checks = checks && res.length === 38;
+                checks = checks && res.length === 30;
                 checks = checks && res[0][0].x === 4893;
                 checks = checks && res[0][0].y === 6001;
                 checks = checks && res[0][0].tmpid === 446213;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.24.0",
+  "version": "0.24.0-scoredist2",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.24.0-scoredist2",
+  "version": "0.24.0-scoredist3",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/src/cpp_util.cpp
+++ b/src/cpp_util.cpp
@@ -101,6 +101,33 @@ ZXY bxy2zxy(unsigned z, unsigned x, unsigned y, unsigned target_z, bool max) {
     return zxy;
 }
 
+constexpr double zoomTileRadius(unsigned zoom) {
+    // Since distance is in tiles we calculate scoredist by converting the miles into
+    // a tile unit value at the appropriate zoom first.
+    //
+    // 32 tiles is about 40 miles at z14, use this as our mile <=> tile conversion.
+    return (32.0 / 40.0) / _pow(1.5, 14 - static_cast<int>(zoom));
+}
+
+// Calculate proximity radius in tiles.
+double proximityRadius(unsigned zoom, double radius) {
+    static constexpr double zoomRadius[9] = {
+        zoomTileRadius(14),
+        zoomTileRadius(13),
+        zoomTileRadius(12),
+        zoomTileRadius(11),
+        zoomTileRadius(10),
+        zoomTileRadius(9),
+        zoomTileRadius(8),
+        zoomTileRadius(7),
+        zoomTileRadius(6)};
+
+    if (zoom >= 6 && zoom <= 14) {
+        return radius * zoomRadius[14 - zoom];
+    }
+    return (radius * (32.0 / 40.0)) / std::pow(1.5, 14 - static_cast<int>(zoom));
+}
+
 // Equivalent of scoredist() function in carmen
 // Combines score and distance into a single score that can be used for sorting.
 // Unlike carmen the effect is not scaled by zoom level as regardless of index
@@ -114,12 +141,6 @@ double scoredist(unsigned zoom, double distance, unsigned short score, double ra
     // here in an abundance of caution.
     if (score > 7) score = 7;
 
-    // Since distance is in tiles we calculate scoredist by converting the miles into
-    // a tile unit value at the appropriate zoom first.
-    //
-    // 32 tiles is about 40 miles at z14, use this as our mile <=> tile conversion.
-    double distRatio = distance / ((radius * (32.0 / 40.0)) / std::pow(1.5, 14 - static_cast<int>(zoom)));
-
     // We don't know the scale of the axis we're modeling, but it doesn't really
     // matter as we just need internal consistency.
     static const double E_POW[8] = {
@@ -131,6 +152,8 @@ double scoredist(unsigned zoom, double distance, unsigned short score, double ra
         148.4131591025766,
         403.4287934927351,
         1096.6331584284585};
+
+    double distRatio = distance / proximityRadius(zoom, radius);
 
     // Too close to 0 the values get intense. Cap it.
     if (distRatio < 0.005) {

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -166,6 +166,8 @@ struct ZXY {
 Cover numToCover(uint64_t num);
 ZXY pxy2zxy(unsigned z, unsigned x, unsigned y, unsigned target_z);
 ZXY bxy2zxy(unsigned z, unsigned x, unsigned y, unsigned target_z, bool max = false);
+
+double proximityRadius(unsigned zoom, double radius);
 double scoredist(unsigned zoom, double distance, unsigned short score, double radius);
 
 inline bool coverSortByRelev(Cover const& a, Cover const& b) noexcept {

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -166,7 +166,7 @@ struct ZXY {
 Cover numToCover(uint64_t num);
 ZXY pxy2zxy(unsigned z, unsigned x, unsigned y, unsigned target_z);
 ZXY bxy2zxy(unsigned z, unsigned x, unsigned y, unsigned target_z, bool max = false);
-double scoredist(unsigned zoom, double distance, double score, double radius);
+double scoredist(unsigned zoom, double distance, unsigned short score, double radius);
 
 inline bool coverSortByRelev(Cover const& a, Cover const& b) noexcept {
     if (b.relev > a.relev)

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -331,11 +331,11 @@ test('coalesce args', (t) => {
             }, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 124.85901539399482, tmpid: 3, x: 3, y: 3 }, '0.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 202.97450261199964, tmpid: 3, x: 3, y: 3 }, '0.0');
                 t.deepEqual(res[1].relev, 1, '1.relev');
                 t.deepEqual(res[1][0], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
                 t.deepEqual(res[2].relev, 0.8, '2.relev');
-                t.deepEqual(res[2][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 3, tmpid: 2, x: 2, y: 2 }, '2.0');
+                t.deepEqual(res[2][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 1.109893833332405, tmpid: 2, x: 2, y: 2 }, '2.0');
                 t.end();
             });
         });
@@ -656,11 +656,11 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
                 t.deepEqual(res[0].relev, 1, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 124.85901539399482, tmpid: 33554435, x: 3, y: 3 }, '0.0');
-                t.deepEqual(res[0][1], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 202.97450261199964, tmpid: 33554435, x: 3, y: 3 }, '1.0');
+                t.deepEqual(res[0][1], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1.0148725130599983, tmpid: 1, x: 1, y: 1 }, '0.1');
+                t.deepEqual(res[1][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '0.0');
+                t.deepEqual(res[1][1], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1.0148725130599983, tmpid: 1, x: 1, y: 1 }, '1.1');
                 t.deepEqual(res[1].relev, 1, '1.relev');
-                t.deepEqual(res[1][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '1.0');
-                t.deepEqual(res[1][1], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '1.1');
                 t.end();
             });
         });
@@ -856,7 +856,7 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0][0].id, 3, 'matches feat 3');
                 t.deepEqual(res[1][0].id, 2, 'matches feat 2');
-                t.deepEqual(res[0][0].distance < res[1][0].distance, true, 'feat 3 is closer than feat2');
+                t.deepEqual(res[0][0].distance < res[1][0].distance, true, 'feat 3 is closer than feat 2');
                 t.end();
             });
         });


### PR DESCRIPTION
Still kinda rough, but this PR is an attempt to fix #133 and make scoredist calculation here more like what's over in carmen cache. Test fixture change here is minimal, I think that's a good sign.

I ended up diverging from doing exactly what is happening over in carmen, what I did carry forward is combining the scores, however I kept things a bit closer to existing implementation. Previously the inverse of the distance was compared to the raw score, this has changed and we now allow the distance to be dominant, or have any affect at all, within the search radius. We still use the inverse of the distance to prefer close features, but also allow for differentiation between features with different scores by adding the a ratio that represent the score.

Todo

- [x] ~Unclear if we really need a gaussian curve here or can get away with something more simple.~ Kept it simple
- [ ] ~If we keep the gauss method it has a constant which need explaining (it's a value from carmen, but not one you'll find in the codebase. It's calculated at load time.)~
- [x] Needs downstream testing and esp with real data.