### PR TITLE
Remove rocksdb related build hacks

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -7,7 +7,6 @@ set -o pipefail
 ./scripts/setup.sh --config local.env
 source local.env
 
-mason install clang++ 3.9.1
 mason install bzip2 1.0.6
 mason install rocksdb 5.4.6
 mason install protozero 1.6.2

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,17 +3,9 @@
 set -eu
 set -o pipefail
 
-# gyp will put "MAKEFLAGS=r -- BUILDTYPE=Release" into the makefiles
-# which breaks the rocksdb build
-unset MAKEFLAGS
-
 # setup mason
 ./scripts/setup.sh --config local.env
 source local.env
-
-# avoid mis-reporting of CPU due to docker
-# from resulting in OOM killer knocking out g++
-export MASON_CONCURRENCY=2
 
 mason install clang++ 3.9.1
 mason install bzip2 1.0.6


### PR DESCRIPTION
These were needed to source compile rocksdb on travis. But we're no longer doing that after https://github.com/mapbox/carmen-cache/commit/14f138ebd31ccd03bc7b38acc2738321d93d2a55#diff-1d889b31bb06cb578abde8e2253d043aL6 (which is awesome) so these things can be removed to avoid any confusion.