### PR TITLE
Add some test files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,12 @@
+/bench
 /build
-/test
+/cloudformation
 /lib/carmen.node
+/local.env
 /mason
 /mason_packages
+/test
+/.codecov.yml
 /.mason
 /.toolchain
-/local.env
+/.travis.yml


### PR DESCRIPTION
There are a few test config files that, while harmless, don't need to be in our npn packages. This PR adds them to .npmignore