### PR TITLE
Deduplicate grids, don't truncate memoized grid prefix lists, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.25.0",
+  "version": "0.25.0-dedupe-1",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.25.0-dedupe-1",
+  "version": "0.25.0-dedupe-2",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.25.0-dedupe-3",
+  "version": "0.25.0-dedupe-4",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.25.0-dedupe-2",
+  "version": "0.25.0-dedupe-3",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mapbox/carmen-cache.git",
     "type": "git"
   },
-  "version": "0.25.0-dedupe-4",
+  "version": "0.25.0-dedupe-5",
   "dependencies": {
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.1"

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -335,9 +335,9 @@ NAN_METHOD(JSCache<T>::_getmatching) {
         bool extended_scan;
         if (info.Length() > 3 && !(info[3]->IsNull() || info[3]->IsUndefined())) {
             if (!info[3]->IsBoolean()) {
-                return Nan::ThrowTypeError("fourth arg, if supplied, must be an Boolean");
+                return Nan::ThrowTypeError("fourth arg, if supplied, must be a boolean");
             }
-            extended_scan = info[2]->BooleanValue();
+            extended_scan = info[3]->BooleanValue();
         } else {
             extended_scan = false;
         }

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -60,9 +60,9 @@ using JSRocksDBCache = JSCache<carmen::RocksDBCache>;
 using JSMemoryCache = JSCache<carmen::MemoryCache>;
 
 template <class T>
-intarray __get(JSCache<T>* c, const std::string& phrase, langfield_type langfield);
+intarray __get(JSCache<T>* c, const std::string& phrase, langfield_type langfield, size_t max_results);
 template <class T>
-intarray __getmatching(JSCache<T>* c, const std::string& phrase, bool match_prefixes, langfield_type langfield);
+intarray __getmatching(JSCache<T>* c, const std::string& phrase, bool match_prefixes, langfield_type langfield, size_t max_results);
 
 struct CoalesceBaton : carmen::noncopyable {
     uv_work_t request;

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -85,7 +85,8 @@ inline std::vector<Context> coalesceSingle(std::vector<PhrasematchSubq>& stack, 
 
     // Load and concatenate grids for all ids in `phrases`
     intarray grids;
-    grids = subq.type == TYPE_MEMORY ? reinterpret_cast<MemoryCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield) : reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield);
+    size_t max_results = subq.extended_scan ? std::numeric_limits<size_t>::max() : PREFIX_MAX_GRID_LENGTH;
+    grids = subq.type == TYPE_MEMORY ? reinterpret_cast<MemoryCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results) : reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results);
 
     unsigned long m = grids.size();
     double relevMax = 0;
@@ -250,7 +251,7 @@ inline std::vector<Context> coalesceMulti(std::vector<PhrasematchSubq>& stack, c
     for (auto const& subq : stack) {
         // Load and concatenate grids for all ids in `phrases`
         intarray grids;
-        grids = subq.type == TYPE_MEMORY ? reinterpret_cast<MemoryCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield) : reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield);
+        grids = subq.type == TYPE_MEMORY ? reinterpret_cast<MemoryCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, PREFIX_MAX_GRID_LENGTH) : reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, PREFIX_MAX_GRID_LENGTH);
 
         bool first = i == 0;
         bool last = i == (stack.size() - 1);

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -94,8 +94,7 @@ inline std::vector<Context> coalesceSingle(std::vector<PhrasematchSubq>& stack, 
                 static_cast<uint64_t>((minx & POW2_14M1) << 20),
                 static_cast<uint64_t>((miny & POW2_14M1) << 34),
                 static_cast<uint64_t>((maxx & POW2_14M1) << 20),
-                static_cast<uint64_t>((maxy & POW2_14M1) << 34)
-            };
+                static_cast<uint64_t>((maxy & POW2_14M1) << 34)};
             grids = reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatchingBboxFiltered(subq.phrase, subq.prefix, subq.langfield, max_results, inplace_bbox);
         } else {
             grids = reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results);
@@ -128,8 +127,7 @@ inline std::vector<Context> coalesceSingle(std::vector<PhrasematchSubq>& stack, 
                 last != NULL &&
                 last->x == cover.x &&
                 last->y == cover.y &&
-                last->score == cover.score
-            ) {
+                last->score == cover.score) {
                 cover.distance = last->distance;
                 cover.scoredist = last->scoredist;
             } else {

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -67,26 +67,40 @@ inline std::vector<Context> coalesceSingle(std::vector<PhrasematchSubq>& stack, 
 
     // bbox (optional)
     bool bbox = !bboxzxy.empty();
-    unsigned minx;
-    unsigned miny;
-    unsigned maxx;
-    unsigned maxy;
+    unsigned short minx;
+    unsigned short miny;
+    unsigned short maxx;
+    unsigned short maxy;
     if (bbox) {
-        minx = static_cast<unsigned>(bboxzxy[1]);
-        miny = static_cast<unsigned>(bboxzxy[2]);
-        maxx = static_cast<unsigned>(bboxzxy[3]);
-        maxy = static_cast<unsigned>(bboxzxy[4]);
+        minx = static_cast<unsigned short>(bboxzxy[1]);
+        miny = static_cast<unsigned short>(bboxzxy[2]);
+        maxx = static_cast<unsigned short>(bboxzxy[3]);
+        maxy = static_cast<unsigned short>(bboxzxy[4]);
     } else {
         minx = 0;
         miny = 0;
-        maxx = 0;
-        maxy = 0;
+        maxx = std::numeric_limits<unsigned short>::max();
+        maxy = std::numeric_limits<unsigned short>::max();
     }
 
     // Load and concatenate grids for all ids in `phrases`
     intarray grids;
     size_t max_results = subq.extended_scan ? std::numeric_limits<size_t>::max() : PREFIX_MAX_GRID_LENGTH;
-    grids = subq.type == TYPE_MEMORY ? reinterpret_cast<MemoryCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results) : reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results);
+    if (subq.type == TYPE_MEMORY) {
+        grids = reinterpret_cast<MemoryCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results);
+    } else {
+        if (subq.extended_scan && bbox) {
+            uint64_t inplace_bbox[4] = {
+                static_cast<uint64_t>((minx & POW2_14M1) << 20),
+                static_cast<uint64_t>((miny & POW2_14M1) << 34),
+                static_cast<uint64_t>((maxx & POW2_14M1) << 20),
+                static_cast<uint64_t>((maxy & POW2_14M1) << 34)
+            };
+            grids = reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatchingBboxFiltered(subq.phrase, subq.prefix, subq.langfield, max_results, inplace_bbox);
+        } else {
+            grids = reinterpret_cast<RocksDBCache*>(subq.cache)->__getmatching(subq.phrase, subq.prefix, subq.langfield, max_results);
+        }
+    }
 
     unsigned long m = grids.size();
     double relevMax = 0;

--- a/src/coalesce.cpp
+++ b/src/coalesce.cpp
@@ -122,9 +122,9 @@ inline std::vector<Context> coalesceSingle(std::vector<PhrasematchSubq>& stack, 
         cover.tmpid = static_cast<uint32_t>(cover.idx * POW2_25 + cover.id);
         cover.relev = cover.relev * subq.weight;
         if (proximity) {
-            auto last = covers.empty() ? NULL : &covers.back();
+            auto last = covers.empty() ? nullptr : &covers.back();
             if (
-                last != NULL &&
+                last != nullptr &&
                 last->x == cover.x &&
                 last->y == cover.y &&
                 last->score == cover.score) {

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -80,7 +80,8 @@ struct PhrasematchSubq {
                     unsigned short i,
                     unsigned short z,
                     uint32_t m,
-                    langfield_type l) : cache(c),
+                    langfield_type l,
+                    bool xs) : cache(c),
                                         type(t),
                                         weight(w),
                                         phrase(p),
@@ -88,7 +89,8 @@ struct PhrasematchSubq {
                                         idx(i),
                                         zoom(z),
                                         mask(m),
-                                        langfield(l) {}
+                                        langfield(l),
+                                        extended_scan(xs) {}
     void* cache;
     char type;
     double weight;
@@ -98,6 +100,7 @@ struct PhrasematchSubq {
     unsigned short zoom;
     uint32_t mask;
     langfield_type langfield;
+    bool extended_scan;
     PhrasematchSubq& operator=(PhrasematchSubq&& c) = default;
     PhrasematchSubq(PhrasematchSubq&& c) = default;
 };

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -86,15 +86,15 @@ struct PhrasematchSubq {
                     uint32_t m,
                     langfield_type l,
                     bool xs) : cache(c),
-                                        type(t),
-                                        weight(w),
-                                        phrase(p),
-                                        prefix(pf),
-                                        idx(i),
-                                        zoom(z),
-                                        mask(m),
-                                        langfield(l),
-                                        extended_scan(xs) {}
+                               type(t),
+                               weight(w),
+                               phrase(p),
+                               prefix(pf),
+                               idx(i),
+                               zoom(z),
+                               mask(m),
+                               langfield(l),
+                               extended_scan(xs) {}
     void* cache;
     char type;
     double weight;

--- a/src/cpp_util.hpp
+++ b/src/cpp_util.hpp
@@ -71,6 +71,10 @@ constexpr uint64_t POW2_14 = static_cast<uint64_t>(_pow(2.0, 14));
 constexpr uint64_t POW2_3 = static_cast<uint64_t>(_pow(2.0, 3));
 constexpr uint64_t POW2_2 = static_cast<uint64_t>(_pow(2.0, 2));
 
+constexpr uint64_t POW2_14M1 = static_cast<uint64_t>(_pow(2.0, 14)) - 1;
+constexpr uint64_t X_MASK = POW2_14M1 << 20;
+constexpr uint64_t Y_MASK = POW2_14M1 << 34;
+
 struct PhrasematchSubq {
     PhrasematchSubq(void* c,
                     char t,

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -18,7 +18,7 @@ intarray MemoryCache::__get(const std::string& phrase, langfield_type langfield)
     return array;
 }
 
-intarray MemoryCache::__getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield) {
+intarray MemoryCache::__getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield, size_t max_results) {
     intarray array;
     std::string phrase = phrase_ref;
 

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -141,11 +141,6 @@ bool MemoryCache::pack(const std::string& filename) {
         // remove duplicates
         varr.erase(std::unique(varr.begin(), varr.end()), varr.end());
 
-        if (varr.size() > PREFIX_MAX_GRID_LENGTH) {
-            // for the prefix memos we're only going to ever use 500k max anyway
-            varr.resize(PREFIX_MAX_GRID_LENGTH);
-        }
-
         packVec(varr, db, item.first);
     }
 

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -81,6 +81,8 @@ bool MemoryCache::pack(const std::string& filename) {
 
             // delta-encode values, sorted in descending order.
             std::sort(varr.begin(), varr.end(), std::greater<uint64_t>());
+            // remove duplicates
+            varr.erase(std::unique(varr.begin(), varr.end()), varr.end());
 
             packVec(varr, db, item.first);
 
@@ -136,6 +138,8 @@ bool MemoryCache::pack(const std::string& filename) {
 
         // delta-encode values, sorted in descending order.
         std::sort(varr.begin(), varr.end(), std::greater<uint64_t>());
+        // remove duplicates
+        varr.erase(std::unique(varr.begin(), varr.end()), varr.end());
 
         if (varr.size() > PREFIX_MAX_GRID_LENGTH) {
             // for the prefix memos we're only going to ever use 500k max anyway

--- a/src/memorycache.cpp
+++ b/src/memorycache.cpp
@@ -53,6 +53,7 @@ intarray MemoryCache::__getmatching(const std::string& phrase_ref, PrefixMatch m
         }
     }
     std::sort(array.begin(), array.end(), std::greater<uint64_t>());
+    if (array.size() > max_results) array.resize(max_results);
     return array;
 }
 

--- a/src/memorycache.hpp
+++ b/src/memorycache.hpp
@@ -19,7 +19,7 @@ class MemoryCache {
     std::vector<uint64_t> _getmatching(std::string phrase, PrefixMatch match_prefixes, std::vector<uint64_t> languages);
 
     std::vector<uint64_t> __get(const std::string& phrase, langfield_type langfield);
-    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield);
+    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield, size_t max_results);
 
     arraycache cache_;
 };

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -103,7 +103,7 @@ intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch 
         uint64_t gridId = rh.top_key();
         rh.pop();
 
-        array.emplace_back(gridId);
+        if (array.size() == 0 || array.back() != gridId) array.emplace_back(gridId);
         sortableGrid* sg = &(grids[gridIdx]);
         sg->it++;
         if (sg->it != sg->end) {

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -117,9 +117,12 @@ intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch 
     return array;
 }
 
-// this is an alternative version of getmatching specifically intended for the
+// This is an alternative version of getmatching specifically intended for the
 // address/partial-number case that parses grid data eagerly rather than lazily
-// and does bbox filtering before sorting
+// and does bbox filtering before sorting. At present we only use it from
+// coalesceSingle, and it's only defined for the RocksDBCache; this filtering is
+// not necessary for correctness, just for performance, so the MemoryCache
+// doesn't need it in order to produce the correct results (and it's slow anyway)
 intarray RocksDBCache::__getmatchingBboxFiltered(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield, size_t max_results, const uint64_t box[4]) {
     intarray array;
     std::string phrase = phrase_ref;

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -18,7 +18,7 @@ intarray RocksDBCache::__get(const std::string& phrase, langfield_type langfield
     return array;
 }
 
-intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield) {
+intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield, size_t max_results) {
     intarray array;
     std::string phrase = phrase_ref;
 
@@ -73,9 +73,9 @@ intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch 
     // as will be the norm for exact matches in translationless indexes
     if (messages.size() == 1) {
         if (std::get<1>(messages[0])) {
-            decodeAndBoostMessage(std::get<0>(messages[0]), array, PREFIX_MAX_GRID_LENGTH);
+            decodeAndBoostMessage(std::get<0>(messages[0]), array, max_results);
         } else {
-            decodeMessage(std::get<0>(messages[0]), array, PREFIX_MAX_GRID_LENGTH);
+            decodeMessage(std::get<0>(messages[0]), array, max_results);
         }
         return array;
     }
@@ -98,7 +98,7 @@ intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch 
         }
     }
 
-    while (!rh.empty() && array.size() < PREFIX_MAX_GRID_LENGTH) {
+    while (!rh.empty() && array.size() < max_results) {
         size_t gridIdx = rh.top_value();
         uint64_t gridId = rh.top_key();
         rh.pop();

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -103,7 +103,7 @@ intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch 
         uint64_t gridId = rh.top_key();
         rh.pop();
 
-        if (array.size() == 0 || array.back() != gridId) array.emplace_back(gridId);
+        if (array.empty() || array.back() != gridId) array.emplace_back(gridId);
         sortableGrid* sg = &(grids[gridIdx]);
         sg->it++;
         if (sg->it != sg->end) {

--- a/src/rocksdbcache.cpp
+++ b/src/rocksdbcache.cpp
@@ -12,7 +12,7 @@ intarray RocksDBCache::__get(const std::string& phrase, langfield_type langfield
     std::string message;
     rocksdb::Status s = db->Get(rocksdb::ReadOptions(), phrase_with_langfield, &message);
     if (s.ok()) {
-        decodeMessage(message, array);
+        decodeMessage(message, array, std::numeric_limits<size_t>::max());
     }
 
     return array;
@@ -73,9 +73,9 @@ intarray RocksDBCache::__getmatching(const std::string& phrase_ref, PrefixMatch 
     // as will be the norm for exact matches in translationless indexes
     if (messages.size() == 1) {
         if (std::get<1>(messages[0])) {
-            decodeAndBoostMessage(std::get<0>(messages[0]), array);
+            decodeAndBoostMessage(std::get<0>(messages[0]), array, PREFIX_MAX_GRID_LENGTH);
         } else {
-            decodeMessage(std::get<0>(messages[0]), array);
+            decodeMessage(std::get<0>(messages[0]), array, PREFIX_MAX_GRID_LENGTH);
         }
         return array;
     }

--- a/src/rocksdbcache.hpp
+++ b/src/rocksdbcache.hpp
@@ -32,13 +32,13 @@ struct sortableGrid {
     sortableGrid(sortableGrid&& c) = default;
 };
 
-inline void decodeMessage(std::string const& message, intarray& array) {
+inline void decodeMessage(std::string const& message, intarray& array, size_t limit) {
     protozero::pbf_reader item(message);
     item.next(CACHE_ITEM);
     auto vals = item.get_packed_uint64();
     uint64_t lastval = 0;
     // delta decode values.
-    for (auto it = vals.first; it != vals.second; ++it) {
+    for (auto it = vals.first; it != vals.second && array.size() < limit; ++it) {
         if (lastval == 0) {
             lastval = *it;
             array.emplace_back(lastval);
@@ -49,13 +49,13 @@ inline void decodeMessage(std::string const& message, intarray& array) {
     }
 }
 
-inline void decodeAndBoostMessage(std::string const& message, intarray& array) {
+inline void decodeAndBoostMessage(std::string const& message, intarray& array, size_t limit) {
     protozero::pbf_reader item(message);
     item.next(CACHE_ITEM);
     auto vals = item.get_packed_uint64();
     uint64_t lastval = 0;
     // delta decode values.
-    for (auto it = vals.first; it != vals.second; ++it) {
+    for (auto it = vals.first; it != vals.second && array.size() < limit; ++it) {
         if (lastval == 0) {
             lastval = *it;
             array.emplace_back(lastval | LANGUAGE_MATCH_BOOST);

--- a/src/rocksdbcache.hpp
+++ b/src/rocksdbcache.hpp
@@ -76,7 +76,7 @@ class RocksDBCache {
     std::vector<std::pair<std::string, langfield_type>> list();
 
     std::vector<uint64_t> __get(const std::string& phrase, langfield_type langfield);
-    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield);
+    std::vector<uint64_t> __getmatching(const std::string& phrase_ref, PrefixMatch match_prefixes, langfield_type langfield, size_t max_results);
 
     std::shared_ptr<rocksdb::DB> db;
 };

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -379,6 +379,27 @@ test('coalesce args', (t) => {
                 t.end();
             });
         });
+        test('coalesceSingle bbox + prox + extendedScan + word_boundary: ' + cache.id, (t) => {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: scan.word_boundary,
+                extendedScan: true
+            }], {
+                bboxzxy: [2, 1, 1, 1, 1],
+                centerzxy: [2,1,1]
+            }, (err, res) => {
+                t.ifError(err, 'no errors');
+                t.deepEqual(res[0].relev, 1, '1.relev');
+                t.deepEqual(res.length, 1, 'got back 1 result');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 1400, tmpid: 1, x: 1, y: 1 }, '1.0');
+                t.end();
+            });
+        });
     });
 })();
 

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -358,6 +358,27 @@ test('coalesce args', (t) => {
                 t.end();
             });
         });
+        test('coalesceSingle bbox + prox + extendedScan: ' + cache.id, (t) => {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 2,
+                weight: 1,
+                phrase: '1',
+                prefix: scan.disabled,
+                extendedScan: true
+            }], {
+                bboxzxy: [2, 1, 1, 1, 1],
+                centerzxy: [2,1,1]
+            }, (err, res) => {
+                t.ifError(err, 'no errors');
+                t.deepEqual(res[0].relev, 1, '1.relev');
+                t.deepEqual(res.length, 1, 'got back 1 result');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 1400, tmpid: 1, x: 1, y: 1 }, '1.0');
+                t.end();
+            });
+        });
     });
 })();
 

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -26,7 +26,7 @@ test('getMatching args', (t) => {
 
     t.throws(() => {
         c._getMatching();
-    }, /expected two or three info: id, match_prefixes, \[languages\]/, 'require args');
+    }, /expected two to four info/, 'require args');
 
     t.throws(() => {
         c._getMatching(false, false);

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -45,6 +45,10 @@ test('getMatching args', (t) => {
         c._getMatching('1', 0, false);
     }, /third arg, if supplied, must be an Array/, 'require array as third arg');
 
+    t.throws(() => {
+        c._getMatching('1', 0, [], 1);
+    }, /fourth arg, if supplied, must be a boolean/, 'require boolean as fourth arg');
+
     t.end();
 });
 
@@ -99,6 +103,12 @@ test('getMatching', (t) => {
         Grid.encode({ id: 82, x: 1, y: 1, relev: 1, score: 1 }),
         Grid.encode({ id: 83, x: 1, y: 1, relev: 1, score: 1 })
     ], [0]);
+
+    const lotsOfThings = [];
+    for (let i = 100; i < 500101; i++) {
+        lotsOfThings.push(Grid.encode({ id: i, x: 1, y: 1, relev: 1, score: 1 }));
+    }
+    cache._set('huge', lotsOfThings, [0]);
 
     // cache A serializes data, cache B loads serialized data.
     const pack = tmpfile();
@@ -272,6 +282,11 @@ test('getMatching', (t) => {
             [81, 82, 83],
             "getMatching for 'word boundary' with word boundary prefix match and no language includes all IDs for 'word boundary'"
         );
+
+        const test_extended_scan_false = c._getMatching('huge', scan.enabled, [0], false);
+        const test_extended_scan_true = c._getMatching('huge', scan.enabled, [0], true);
+        t.equal(test_extended_scan_false.length, 500000, "list is truncated when extended_scan is false");
+        t.equal(test_extended_scan_true.length, 500001, "list is not truncated when extended_scan is true");
     });
 
     // t.deepEqual(loader.list('grid'), [ 'else.', 'something', 'test', 'test.' ], 'keys in shard');

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -285,8 +285,8 @@ test('getMatching', (t) => {
 
         const test_extended_scan_false = c._getMatching('huge', scan.enabled, [0], false);
         const test_extended_scan_true = c._getMatching('huge', scan.enabled, [0], true);
-        t.equal(test_extended_scan_false.length, 500000, "list is truncated when extended_scan is false");
-        t.equal(test_extended_scan_true.length, 500001, "list is not truncated when extended_scan is true");
+        t.equal(test_extended_scan_false.length, 500000, 'list is truncated when extended_scan is false');
+        t.equal(test_extended_scan_true.length, 500001, 'list is not truncated when extended_scan is true');
     });
 
     // t.deepEqual(loader.list('grid'), [ 'else.', 'something', 'test', 'test.' ], 'keys in shard');


### PR DESCRIPTION
This PR introduces several changes in support of mapbox/carmen#813 , which adds autocomplete support for number-only address queries.

The changes:
- [x] deduplicate grids in grid lists at grid cache pack time; duplicates can often occur especially in the memoized prefix lists, as multiple synonyms for the same feature that share a prefix can mean the same grid gets added to the memo list multiple times
- [x] stop truncating memoized prefix lists at pack time
- [x] make it possible to opt into a full scan of all matching features rather than just the first 500k
- [x] expose that ^ mechanism both to the `getMatching` call and `coalesceSingle` via a flag on phrasematch objects (note: this property is currently not respected by coalesceMulti; this would be easy to change, but I think it's probably a useful footgun protection for the moment)
- [x] make some additional changes to coalesceSingle's order of operations when scanning grids to increase efficiency and reduce duplication
UPDATE 6 Feb:
- [x] add an alternative version of `getMatching` that gets opted into in coalesceSingle if both extendedScan and bbox are enabled that uses some bit arithmetic to prefilter the matched grids before sorting them -- it now does the sort all at once using `std::sort` at the end, but only on the filtered list. More notes:
    * I also played with a version that tried to do a smarter sort using repeated calls to `std::merge`, since the list we're sorting is comprised of a sequence of already-sorted lists. Turned out that once the prefiltering was done, the remaining list was small enough in practice that this approach didn't yield a significant performance improvement (sorting a few thousand things just doesn't take very long) but was much more complicated code-wise, so I ditched it.
    * this new version of getMatching isn't exposed directly to Javascript, so it's only testable at present indirectly via calls to `coalesceSingle`. Eventually though, I think we'll want to reunify them through a new index format that allows for geometry-aware operations and avoids all these giant sorts in the first place, so I don't think building out a big JS-side apparatus for what's essentially a hack is worth the bother right now. We're still good coverage-wise.

To do:
- [x] add tests of the new functionality