### PR TITLE
Distance floor

### DIFF
--- a/src/cpp_util.cpp
+++ b/src/cpp_util.cpp
@@ -156,7 +156,7 @@ double scoredist(unsigned zoom, double distance, unsigned short score, double ra
     // Too close to 0 the scoredist values get intense. Give distance a floor.
     if (distance < 1) {
         // Something greater than 0 but less than 1, to avoid dividing by 0
-        distance = 0.5;
+        distance = 0.8;
     }
 
     double distRatio = distance / proximityRadius(zoom, radius);

--- a/src/cpp_util.cpp
+++ b/src/cpp_util.cpp
@@ -153,14 +153,16 @@ double scoredist(unsigned zoom, double distance, unsigned short score, double ra
         403.4287934927351,
         1096.6331584284585};
 
+    // Too close to 0 the scoredist values get intense. Give distance a floor.
+    if (distance < 1) {
+        // Something greater than 0 but less than 1, to avoid dividing by 0
+        distance = 0.5;
+    }
+
     double distRatio = distance / proximityRadius(zoom, radius);
 
-    // Too close to 0 the values get intense. Cap it.
-    if (distRatio < 0.005) {
-        distRatio = 0.005;
-    }
     // Beyond the proximity radius just let scoredist be driven by score.
-    else if (distRatio > 1.0) {
+    if (distRatio > 1.0) {
         distRatio = 1.00;
     }
 

--- a/test/coalesce.proximity.test.js
+++ b/test/coalesce.proximity.test.js
@@ -134,6 +134,60 @@ const test = require('tape');
     const cache = new MemoryCache('a', 0);
     const cov = {
         id: 1,
+        x: 1,
+        y: 1,
+        relev: 1,
+        score: 0
+    };
+    cache._set('1', [Grid.encode(cov)]);
+
+
+    test('Calculates distance correctly for features on same tile as proximity', (t) => {
+        coalesce([{
+            cache: cache,
+            mask: 1 << 0,
+            idx: 0,
+            zoom: 14,
+            weight: 1,
+            phrase: '1',
+            prefix: scan.disabled
+        }], {
+            radius: 400,
+            centerzxy: [14, 1, 1]
+        }, (err, res) => {
+            t.ifError(err, 'no errors');
+            t.equal(res[0][0].distance, 0, 'Distance for a feature on the same cover as the proximity point should be 0');
+            t.equal(res[0][0].scoredist, 643.5016267477292, 'Scoredist shoud be 643.5016267477292');
+            t.end();
+        });
+    });
+
+    test('Calculates distance correctly for features 1 tile away from proximity', (t) => {
+        coalesce([{
+            cache: cache,
+            mask: 1 << 0,
+            idx: 0,
+            zoom: 14,
+            weight: 1,
+            phrase: '1',
+            prefix: scan.disabled
+        }], {
+            radius: 400,
+            centerzxy: [14, 1, 2]
+        }, (err, res) => {
+            t.ifError(err, 'no errors');
+            t.equal(res[0][0].distance, 1, 'Distance for a feature 1 tile away from proximity point should be 1');
+            t.equal(res[0][0].scoredist, 321.7508133738646, 'Scoredist shoud be 321.7508133738646');
+            t.end();
+        });
+    });
+})();
+
+
+(function() {
+    const cache = new MemoryCache('a', 0);
+    const cov = {
+        id: 1,
         x: 0,
         y: 0,
         relev: 1,

--- a/test/coalesce.proximity.test.js
+++ b/test/coalesce.proximity.test.js
@@ -157,7 +157,7 @@ const test = require('tape');
         }, (err, res) => {
             t.ifError(err, 'no errors');
             t.equal(res[0][0].distance, 0, 'Distance for a feature on the same cover as the proximity point should be 0');
-            t.equal(res[0][0].scoredist, 643.5016267477292, 'Scoredist shoud be 643.5016267477292');
+            t.equal(res[0][0].scoredist, 402.1885167173308, 'Scoredist shoud be 402.1885167173308');
             t.end();
         });
     });

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -291,7 +291,7 @@ test('coalesce args', (t) => {
             x: 1,
             y: 1,
             relev: 1,
-            score: 7
+            score: 3
         })
     ]);
     const rockscache = toRocksCache(memcache);
@@ -302,14 +302,14 @@ test('coalesce args', (t) => {
                 cache: cache,
                 mask: 1 << 0,
                 idx: 0,
-                zoom: 2,
+                zoom: 14,
                 weight: 1,
                 phrase: '1',
                 prefix: scan.disabled
             }], {}, (err, res) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '0.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 3, scoredist: 3, tmpid: 1, x: 1, y: 1 }, '0.0');
                 t.deepEqual(res[1].relev, 1, '1.relev');
                 t.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 1, tmpid: 3, x: 3, y: 3 }, '1.0');
                 t.deepEqual(res[2].relev, 0.8, '2.relev');
@@ -322,7 +322,7 @@ test('coalesce args', (t) => {
                 cache: cache,
                 mask: 1 << 0,
                 idx: 0,
-                zoom: 2,
+                zoom: 6,
                 weight: 1,
                 phrase: '1',
                 prefix: scan.disabled
@@ -330,11 +330,14 @@ test('coalesce args', (t) => {
                 centerzxy: [3,3,3]
             }, (err, res) => {
                 t.ifError(err, 'no errors');
+                t.equal(res[0][0].id, 3, 'First result is the closest, even if its a slightly lower score');
+                t.equal(res[1][0].id, 1, 'Second result is the closest');
+                t.equal(res[2][0].id, 2, 'Third result is the least relevant, even if its closer than the 1st result');
                 t.deepEqual(res[0].relev, 1, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 202.97450261199964, tmpid: 3, x: 3, y: 3 }, '0.0');
                 t.deepEqual(res[1].relev, 1, '1.relev');
-                t.deepEqual(res[1][0], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
                 t.deepEqual(res[2].relev, 0.8, '2.relev');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 0, relev: 1.0, score: 1, scoredist: 1.5839497841387566, tmpid: 3, x: 3, y: 3 }, '0.0');
+                t.deepEqual(res[1][0], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 1.0, score: 3, scoredist: 1.109893833332405, tmpid: 1, x: 1, y: 1 }, '1.0');
                 t.deepEqual(res[2][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 0, relev: 0.8, score: 3, scoredist: 1.109893833332405, tmpid: 2, x: 2, y: 2 }, '2.0');
                 t.end();
             });
@@ -344,7 +347,7 @@ test('coalesce args', (t) => {
                 cache: cache,
                 mask: 1 << 0,
                 idx: 0,
-                zoom: 2,
+                zoom: 6,
                 weight: 1,
                 phrase: '1',
                 prefix: scan.disabled
@@ -354,7 +357,7 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '1.relev');
                 t.deepEqual(res.length, 1, 'got back 1 result');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 7, tmpid: 1, x: 1, y: 1 }, '1.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 3, scoredist: 3, tmpid: 1, x: 1, y: 1 }, '1.0');
                 t.end();
             });
         });
@@ -363,7 +366,7 @@ test('coalesce args', (t) => {
                 cache: cache,
                 mask: 1 << 0,
                 idx: 0,
-                zoom: 2,
+                zoom: 6,
                 weight: 1,
                 phrase: '1',
                 prefix: scan.disabled,
@@ -375,7 +378,7 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '1.relev');
                 t.deepEqual(res.length, 1, 'got back 1 result');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 1400, tmpid: 1, x: 1, y: 1 }, '1.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 3, scoredist: 1.7322531402718835, tmpid: 1, x: 1, y: 1 }, '1.0');
                 t.end();
             });
         });
@@ -384,7 +387,7 @@ test('coalesce args', (t) => {
                 cache: cache,
                 mask: 1 << 0,
                 idx: 0,
-                zoom: 2,
+                zoom: 6,
                 weight: 1,
                 phrase: '1',
                 prefix: scan.word_boundary,
@@ -396,12 +399,63 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 t.deepEqual(res[0].relev, 1, '1.relev');
                 t.deepEqual(res.length, 1, 'got back 1 result');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 7, scoredist: 1400, tmpid: 1, x: 1, y: 1 }, '1.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 1.0, score: 3, scoredist: 1.7322531402718835, tmpid: 1, x: 1, y: 1 }, '1.0');
                 t.end();
             });
         });
     });
 })();
+
+(function() {
+    const memcache = new MemoryCache('a', 0);
+    memcache._set('1', [
+        Grid.encode({
+            id: 2,
+            x: 2,
+            y: 2,
+            relev: 0.8,
+            score: 3
+        }),
+        Grid.encode({
+            id: 3,
+            x: 3,
+            y: 3,
+            relev: 1,
+            score: 1
+        }),
+        Grid.encode({
+            id: 1,
+            x: 1,
+            y: 1,
+            relev: 1,
+            score: 7
+        })
+    ]);
+    const rockscache = toRocksCache(memcache);
+
+    [memcache, rockscache].forEach((cache) => {
+        test('coalesceSingle proximity with a feature with max score at zoom 6: ' + cache.id, (t) => {
+            coalesce([{
+                cache: cache,
+                mask: 1 << 0,
+                idx: 0,
+                zoom: 6,
+                weight: 1,
+                phrase: '1',
+                prefix: scan.disabled
+            }], {
+                centerzxy: [3,3,3]
+            }, (err, res) => {
+                t.ifError(err, 'no errors');
+                t.equal(res[0][0].id, 1, 'First result is the one with the highest score possible, even if its not the closest');
+                t.equal(res[1][0].id, 3, 'Second result is the closest, since it has a much lower score');
+                t.equal(res[2][0].id, 2, 'Third result is the least relevant, even if its closer than the 1st result');
+                t.end();
+            });
+        });
+    });
+})();
+
 
 // exercise the sort function -- the coverage tool required testing all lines
 // of the sort comparator function, so this test just ensures that the sort operator
@@ -622,7 +676,7 @@ test('coalesce args', (t) => {
             x: 2,
             y: 2,
             relev: 1,
-            score: 7
+            score: 3
         }),
         Grid.encode({
             id: 3,
@@ -667,7 +721,7 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
                 t.deepEqual(res[0].relev, 1, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '0.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 2, idx: 1, relev: 0.5, score: 3, scoredist: 3, tmpid: 33554434, x: 2, y: 2 }, '0.0');
                 t.deepEqual(res[0][1], { matches_language: true, distance: 0, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1, tmpid: 1, x: 1, y: 1 }, '0.1');
                 t.deepEqual(res[1].relev, 1, '1.relev');
                 t.deepEqual(res[1][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1, tmpid: 33554435, x: 3, y: 3 }, '1.0');
@@ -698,9 +752,9 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 // sorts by relev, score
                 t.deepEqual(res[0].relev, 1, '0.relev');
-                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 202.97450261199964, tmpid: 33554435, x: 3, y: 3 }, '1.0');
+                t.deepEqual(res[0][0], { matches_language: true, distance: 0, id: 3, idx: 1, relev: 0.5, score: 1, scoredist: 1.5839497841387566, tmpid: 33554435, x: 3, y: 3 }, '1.0');
                 t.deepEqual(res[0][1], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1.0148725130599983, tmpid: 1, x: 1, y: 1 }, '0.1');
-                t.deepEqual(res[1][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 1, relev: 0.5, score: 7, scoredist: 7, tmpid: 33554434, x: 2, y: 2 }, '0.0');
+                t.deepEqual(res[1][0], { matches_language: true, distance: 1.4142135623730951, id: 2, idx: 1, relev: 0.5, score: 3, scoredist: 1.109893833332405, tmpid: 33554434, x: 2, y: 2 }, '0.0');
                 t.deepEqual(res[1][1], { matches_language: true, distance: 2.8284271247461903, id: 1, idx: 0, relev: 0.5, score: 1, scoredist: 1.0148725130599983, tmpid: 1, x: 1, y: 1 }, '1.1');
                 t.deepEqual(res[1].relev, 1, '1.relev');
                 t.end();

--- a/test/coalesce.test.js
+++ b/test/coalesce.test.js
@@ -302,7 +302,7 @@ test('coalesce args', (t) => {
                 cache: cache,
                 mask: 1 << 0,
                 idx: 0,
-                zoom: 14,
+                zoom: 6,
                 weight: 1,
                 phrase: '1',
                 prefix: scan.disabled
@@ -413,7 +413,7 @@ test('coalesce args', (t) => {
             id: 2,
             x: 2,
             y: 2,
-            relev: 0.8,
+            relev: 1,
             score: 3
         }),
         Grid.encode({
@@ -449,7 +449,7 @@ test('coalesce args', (t) => {
                 t.ifError(err, 'no errors');
                 t.equal(res[0][0].id, 1, 'First result is the one with the highest score possible, even if its not the closest');
                 t.equal(res[1][0].id, 3, 'Second result is the closest, since it has a much lower score');
-                t.equal(res[2][0].id, 2, 'Third result is the least relevant, even if its closer than the 1st result');
+                t.equal(res[2][0].id, 2, 'Third result has a higher score than the second but is farther away than the second result');
                 t.end();
             });
         });


### PR DESCRIPTION
# Distance floor PR

## Context

In calculating scoredist, the distratio had a [hard-coded minimum value of 0.005](https://github.com/mapbox/carmen-cache/blob/master/src/cpp_util.cpp#L158-L161). The rationale behind this was that if as distratio approaches zero, the scordist value gets exponentially higher. The cap at 0.05 was hard-coded based on a proximity radius of 200, assuming that 0.05 was the minimum reasonable value (more explanation below).


This value of 0.005 is based on the minimum reasonable value for a proximity radius closer to 200. The problem is that when the proximity radius passed in to coalesce is higher, say 400, there is meaningful differentiation in the values that are less than 0.005.

Alternatively, any distance less than 1 isn't meaningful, since something on the same tile as the proximity point will be 0, and something one tile away will have a distance of >=1.

This PR sets a minimum distance, instead of a minimum distRatio.


## Summary of changes
- [x] Give distance a minimum value to avoid distRatios that approach zero, and exponentially high scoredists


## Next steps
- [x] More comprehensive analysis of different zoom levels, proximity radius values, and scores
- [x] Potentially evaluate whether something like 0.9 would make more sense than 0.5

## More in-depth explanation

[**zoomTileRadius**](https://github.com/mapbox/carmen-cache/blob/master/src/cpp_util.cpp#L104-L110) converts miles into a tile unit value. For zoom 14, it would be `0.8`:

```
    // 32 tiles is about 40 miles at z14, use this as our mile <=> tile conversion.
    return (32.0 / 40.0) / _pow(1.5, 14 - static_cast<int>(zoom)); // 0.8 / 1.5^0 = 0.8
```
[**proximityRadius**](https://github.com/mapbox/carmen-cache/blob/master/src/cpp_util.cpp#L113-L129) for zoom 14, and radius 400 would be `320` (as opposed to `160` for radius 200):

```
    if (zoom >= 6 && zoom <= 14) {
        return radius * zoomRadius[14 - zoom]; // 400 * 0.8 = 320
    }
```

[**distRatio**](https://github.com/mapbox/carmen-cache/blob/master/src/cpp_util.cpp#L156-L165) for zoom 14, distance 0, score 0, radius 400 would previously have been capped at 0.005:

**Previously:**

```
    double distRatio = distance / proximityRadius(zoom, radius); 
    // For a distance of 0 and radius of 400: 0 / 320 = 0
    // For a distance of 1 and radius of 400: 1/320 = 0.003125
    
    // Too close to 0 the values get intense. Cap it.
    if (distRatio < 0.005) {
        distRatio = 0.005;
    }
    // Both would return 0.005, resulting in no differentiation
```
If the feature was 1 tile away from the proximity point, with a radius of 200 (so proximityRadius of 160), the distRatio woud have been `1/160 = 0.00625`. That’s why a minimum of `0.005` made sense. If the proximity radius is 400 though, the distRatio for 1/320 would be  `0.003125`, which is under the 0.005 threshold. This means that there was no distinction in scoredist between a distance of 0 and a distance of 1, so features on the same tile as the proximity point were not getting sorted higher than features 1 tile away.


**Now:**

```
    // Too close to 0 the scoredist values get intense. Give distance a floor.
    if (distance < 1) {
        // Something greater than 0 but less than 1, to avoid dividing by 0
        distance = 0.5;
    }
    double distRatio = distance / proximityRadius(zoom, radius); 
    
    // For a distance of 0, corrected to 0.05: 0.5 / 320 = 0.0015625
    // For a distance of 1: 1/320 = 0.003125
    // There is meaningful differentiation in these values
   ``` 

[**scoreDist**](https://github.com/mapbox/carmen-cache/blob/master/src/cpp_util.cpp#L167)**:** 
```
    static const double E_POW[8] = {
        1,
        2.718281828459045,
        7.38905609893065,
        20.085536923187668,
        54.598150033144236,
        148.4131591025766,
        403.4287934927351,
        1096.6331584284585};
    
    // distratio calculations ...
    
    return ((6 * E_POW[score] / E_POW[7]) + 1) / distRatio;
    // For score 0, distRatio 0.0015625: ((6 * 1) / 1096.63) + 1) / 0.0015625 = ~643.50163
    // For score 0, distRatio 0.003125: ((6 * 1) / 1096.63) + 1) / 0.003125 = ~321.75081
```

## Open question:

What are the limits of this for different zoom levels, scores and proximity radius values? Is it still necessary to have another cap to avoid astronomically high scoredists?
